### PR TITLE
Project deployment tokens

### DIFF
--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -70,6 +70,18 @@ composer-home:
         - require:
             - environ: composer-home
 
+{% if pillar.elife.deploy_user.github_token %}
+composer-auth:
+    environ.setenv:
+        - name: COMPOSER_AUTH
+        - value: '{"github-oauth": { "github.com": "{{ pillar.elife.deploy_user.github_token }}" } }'
+{% else %}
+composer-auth:
+    environ.setenv:
+        - name: COMPOSER_AUTH
+        - value: ''
+{% endif %}
+
 install-composer:
     cmd.run:
         - cwd: /usr/local/bin/
@@ -79,6 +91,7 @@ install-composer:
         - require:
             - cmd: php
             - environ: composer-home
+            - environ: composer-auth
         - unless:
             - which composer
 

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -10,6 +10,8 @@ elife:
         aws_access: null
         aws_secret: null
         aws_region: us-east-1
+        key: null
+        github_token: null
 
     ssh_users: 
         # username: pubkey


### PR DESCRIPTION
Default for `key`, but also for `github_token` which will be used by Composer. Like for the key, the token won't be stored in the machine running Composer.

(technically it may be stored by Salt in its cache with root ownership, but not in ~/.composer)