### PR TITLE
builder.environ_setenv_sensitive custom state

### DIFF
--- a/_states/builder.py
+++ b/_states/builder.py
@@ -1,0 +1,28 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+def environ_setenv_sensitive(**kwargs):
+    '''
+    This state works as environ.setenv, but avoids printing the values of
+    environment variables, considering them sensitive (e.g. a Github token).
+
+    See 'environ.setenv' for parameters, which are passed to it transparently.
+
+    Example of output:
+    ```
+    ==> journal--vagrant:           ID: composer-auth
+    ==> journal--vagrant:     Function: builder.environ_setenv_sensitive
+    ==> journal--vagrant:         Name: COMPOSER_AUTH
+    ==> journal--vagrant:       Result: True
+    ==> journal--vagrant:      Comment: Environ values were set
+    ==> journal--vagrant:      Started: 08:37:04.437606
+    ==> journal--vagrant:     Duration: 2.722 ms
+    ==> journal--vagrant:      Changes:
+    ==> journal--vagrant:               ----------
+    ==> journal--vagrant:               COMPOSER_AUTH:
+    ==> journal--vagrant:                   ***SENSITIVE***
+    '''
+    ret = __states__['environ.setenv'](**kwargs)
+    ret['changes'] = {key: '***SENSITIVE***' for key in ret['changes']}
+    return ret

--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -72,7 +72,7 @@ composer-home:
 
 {% if pillar.elife.deploy_user.github_token %}
 composer-auth:
-    environ.setenv:
+    builder.environ_setenv_sensitive:
         - name: COMPOSER_AUTH
         - value: '{"github-oauth": { "github.com": "{{ pillar.elife.deploy_user.github_token }}" } }'
 {% else %}
@@ -91,7 +91,7 @@ install-composer:
         - require:
             - cmd: php
             - environ: composer-home
-            - environ: composer-auth
+            - composer-auth
         - unless:
             - which composer
 


### PR DESCRIPTION
This state works as environ.setenv, but avoids printing the values of
environment variables, considering them sensitive (e.g. a Github token).

Example of output:
```
==> journal--vagrant:           ID: composer-auth
==> journal--vagrant:     Function: builder.environ_setenv_sensitive
==> journal--vagrant:         Name: COMPOSER_AUTH
==> journal--vagrant:       Result: True
==> journal--vagrant:      Comment: Environ values were set
==> journal--vagrant:      Started: 08:37:04.437606
==> journal--vagrant:     Duration: 2.722 ms
==> journal--vagrant:      Changes:
==> journal--vagrant:               ----------
==> journal--vagrant:               COMPOSER_AUTH:
==> journal--vagrant:                   ***SENSITIVE***
==> journal--vagrant: ----------
```