### PR TITLE
Removing uploadprogress extension installation attempt

### DIFF
--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -47,14 +47,6 @@ php-log:
         - user: {{ pillar.elife.webserver.username }}
         - mode: 640
 
-pecl-uploadprogress:
-    cmd.run:
-        - name: pecl install uploadprogress
-        - unless:
-            - pecl list | grep uploadprogress
-        - require:
-            - cmd: php
-       
 #
 # Composer (php package management)
 #


### PR DESCRIPTION
This extension from PECL has not been updated since 2011, and it only
works with Apache but we use Nginx.

It does not compile on PHP 7:
```
==> journal-cms--vagrant:
/tmp/pear/temp/uploadprogress/uploadprogress.c:458:20: error:
'php_stream_copy_to_mem' undeclared (first use in this function)
==> journal-cms--vagrant:                            if ((len =
php_stream_copy_to_mem(stream, &contents, maxlen, 0)) > 0) {
==> journal-cms--vagrant:                                       ^
==> journal-cms--vagrant:
/tmp/pear/temp/uploadprogress/uploadprogress.c:466:44: error: macro
"RETVAL_STRINGL" passed 3 arguments, but takes just 2
==> journal-cms--vagrant:
RETVAL_STRINGL(contents, len, 0);
==> journal-cms--vagrant:
^
==> journal-cms--vagrant:
/tmp/pear/temp/uploadprogress/uploadprogress.c:466:13: error:
'RETVAL_STRINGL' undeclared (first use in this function)
==> journal-cms--vagrant:
RETVAL_STRINGL(contents, len, 0);
==> journal-cms--vagrant:                                ^
==> journal-cms--vagrant:                   make: ***
[uploadprogress.lo] Error 1
==> journal-cms--vagrant:                   ERROR: `make' failed

but still exits with return code 0 so no one notices.
```