### PR TITLE
States for installing proofreader as a Composer global dependency

### DIFF
--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -119,3 +119,12 @@ composer-permissions:
             - group
         - require:
             - cmd: update-composer
+
+# useful to depend on
+composer:
+    cmd.run:
+        - name: composer --version
+        - require:
+            - composer-permissions
+            - composer-global-paths
+        

--- a/elife/proofreader-php.sls
+++ b/elife/proofreader-php.sls
@@ -1,0 +1,6 @@
+proofreader-php:
+    cmd.run:
+        - name: composer global require elife/proofreader-php=dev-master
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - composer


### PR DESCRIPTION
The requirements for tools (which is what we install as Composer global rather than as a project dependency) become relaxed to allow installation of packages without releases (from dev-master).
There is a new `composer` state that collects all the Composer setup operations to make it easy to require it from other states.