### PR TITLE
Wrapper for git.latest to build pull requests

### DIFF
--- a/_states/builder.py
+++ b/_states/builder.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 log = logging.getLogger(__name__)
 
@@ -25,4 +26,33 @@ def environ_setenv_sensitive(**kwargs):
     '''
     ret = __states__['environ.setenv'](**kwargs)
     ret['changes'] = {key: '***SENSITIVE***' for key in ret['changes']}
+    return ret
+
+def git_latest(**kwargs):
+    '''
+    This state allows extending the behavior of git.latest by passing
+    additional parameters:
+
+    fetch_pull_requests
+        Performs a `git fetch '*refs/pull/*:refs/pull/*' before 
+        starting, to ensure the head and merge commits of PRs
+        are available as a revision to switch to.
+    '''
+    fetch_pull_requests = kwargs.pop('fetch_pull_requests', False)
+    target = kwargs.get('target')
+    is_git_repository_existing = os.path.isdir(target)
+    if fetch_pull_requests and is_git_repository_existing:
+        refspecs = [
+            '+refs/pull/*:refs/pull/*',
+        ]
+        _fetch_changes = __salt__['git.fetch'](
+            target,
+            remote=kwargs.get('remote', 'origin'),
+            force=True,
+            refspecs=refspecs,
+            user=kwargs.get('user'),
+            identity=kwargs.get('identity')
+        )
+
+    ret = __states__['git.latest'](**kwargs)
     return ret

--- a/_states/builder.py
+++ b/_states/builder.py
@@ -40,8 +40,8 @@ def git_latest(**kwargs):
     '''
     fetch_pull_requests = kwargs.pop('fetch_pull_requests', False)
     target = kwargs.get('target')
-    is_git_repository_existing = os.path.isdir(target)
-    if fetch_pull_requests and is_git_repository_existing:
+    git_repository_exists = os.path.isdir(target)
+    if fetch_pull_requests and git_repository_exists:
         refspecs = [
             '+refs/pull/*:refs/pull/*',
         ]
@@ -53,6 +53,5 @@ def git_latest(**kwargs):
             user=kwargs.get('user'),
             identity=kwargs.get('identity')
         )
-
     ret = __states__['git.latest'](**kwargs)
     return ret


### PR DESCRIPTION
git.latest does not fetch pull requests (`refs/pull/*`) from the origin repository; so when a pull request from a fork comes in, attempts of builder to perform `buildvars.switch_revision_update_instance` to that revision fail for the missing commit.

This state can be used in projects that want to build pull requests by adding `fetch_pull_requests: True` to their configuration (and changing the name of the state)