### PR TITLE
Improvements to PHP log

### DIFF
--- a/elife/config/etc-php-7.0-cli-php.ini
+++ b/elife/config/etc-php-7.0-cli-php.ini
@@ -296,7 +296,7 @@ serialize_precision = 17
 ; This directive allows you to disable certain functions for security reasons.
 ; It receives a comma-delimited list of function names.
 ; http://php.net/disable-functions
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
+disable_functions =
 
 ; This directive allows you to disable certain classes for security reasons.
 ; It receives a comma-delimited list of class names.
@@ -356,7 +356,7 @@ zend.enable_gc = On
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; http://php.net/expose-php
-expose_php = Off
+expose_php = On
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;
@@ -386,7 +386,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -459,7 +459,7 @@ error_reporting = E_ALL
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/display-errors
-display_errors = Off
+display_errors = stderr
 
 ; The display of errors which occur during PHP's startup sequence are handled
 ; separately from display_errors. PHP's default behavior is to suppress those
@@ -663,11 +663,10 @@ auto_prepend_file =
 ; http://php.net/auto-append-file
 auto_append_file =
 
-; By default, PHP will output a character encoding using
-; the Content-type: header.  To disable sending of the charset, simply
-; set it to be empty.
+; By default, PHP will output a media type using the Content-Type header. To
+; disable this, simply set it to be empty.
 ;
-; PHP's built-in default is text/html
+; PHP's built-in default media type is set to text/html.
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 
@@ -759,8 +758,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;; elife 2015-04-10
-cgi.fix_pathinfo=0
+;cgi.fix_pathinfo=1
 
 ; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
 ; security tokens of the calling client.  This allows IIS to define the
@@ -868,6 +866,7 @@ default_socket_timeout = 60
 ;extension=php_bz2.dll
 ;extension=php_curl.dll
 ;extension=php_fileinfo.dll
+;extension=php_ftp.dll
 ;extension=php_gd2.dll
 ;extension=php_gettext.dll
 ;extension=php_gmp.dll
@@ -956,6 +955,7 @@ cli_server.color = On
 ; happens within intl functions. The value is the level of the error produced.
 ; Default is 0, which does not produce any errors.
 ;intl.error_level = E_WARNING
+;intl.use_exceptions = 0
 
 [sqlite3]
 ;sqlite3.extension_dir =

--- a/elife/jenkins-scripts/notify_slack.sh
+++ b/elife/jenkins-scripts/notify_slack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-curl -v -d "{\"text\":\"$1\", \"username\":\"alfred\", \"icon_url\":\"http://ci.alfred.elifesciences.org/favicon.ico\"}" $SLACK_CHANNEL_HOOK
+curl -v -d "{\"text\":\"$1\", \"username\":\"alfred\", \"icon_url\":\"http://ci--alfred.elifesciences.org/favicon.ico\"}" $SLACK_CHANNEL_HOOK
 

--- a/elife/nginx-php7.sls
+++ b/elife/nginx-php7.sls
@@ -14,7 +14,8 @@ php-fpm-config:
         - name: /etc/php/7.0/fpm/php.ini
         - source: salt://elife/config/etc-php-7.0-fpm-php.ini
         - require:
-            - pkg: php-nginx-deps
+            - php-nginx-deps
+            - php-log
 
 php-fpm:
     # nginx config needs to target this sock file. 

--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -45,8 +45,18 @@ php-log:
     file.managed:
         - name: /var/log/php_errors.log
         - user: {{ pillar.elife.webserver.username }}
-        - mode: 640
+        - group: {{ pillar.elife.webserver.username }}
+        - mode: 660
         - replace: False
+
+php-cli-config:
+    file.managed:
+        - name: /etc/php/7.0/cli/php.ini
+        - source: salt://elife/config/etc-php-7.0-cli-php.ini
+        - require:
+            - php
+            - php-log
+
 
 #
 # Composer (php package management)


### PR DESCRIPTION
- Provisioning also the one for cli
- `elife` user can write in the log, as part of `www-data` group
- Displaying errors for cli scripts
- All errors in a single file
- `error_reporting` as much as possible

@thewilkybarkid @nlisgo