### PR TITLE
Making ENVIRONMENT_NAME available to cli scripts

### DIFF
--- a/elife/config/etc-profile.d-environment-name.sh
+++ b/elife/config/etc-profile.d-environment-name.sh
@@ -1,0 +1,1 @@
+export ENVIRONMENT_NAME={{ pillar.elife.env }}

--- a/elife/environment-name.sls
+++ b/elife/environment-name.sls
@@ -1,0 +1,6 @@
+environment-name:
+    file.managed:
+        - name: /etc/profile.d/environment-name.sh
+        - source: salt://elife/config/etc-profile.d-environment-name.sh
+        - template: jinja
+        - mode: 644

--- a/elife/init.sls
+++ b/elife/init.sls
@@ -11,3 +11,4 @@ include:
     - .security
     - .logging
     - .daily-system-updates
+    - .environment-name


### PR DESCRIPTION
This is useful in all sorts of situations, like environment checks in some scripts to safely stop themselves from running in production.