### PR TITLE
Avoid creating twice root db users if RDS is the only one being used

### DIFF
--- a/elife/postgresql.sls
+++ b/elife/postgresql.sls
@@ -45,20 +45,18 @@ rds-postgresql-user:
         - login: True
         - require:
             - pkg: postgresql
-{% endif %}
-
+{% else %}
 postgresql-user:
     postgres_user.present:
         - name: {{ pillar.elife.db_root.username }}
         - password: {{ pillar.elife.db_root.password }}
         - refresh_password: True
         - db_password: {{ pillar.elife.db_root.password }}
-        
         # doesn't work on RDS instances
         - superuser: True
-
         - login: True
         - require:
             - pkg: postgresql
             - service: postgresql
+{% endif %}
 


### PR DESCRIPTION
I thought it was confusing to create also a local root user when RDS is the real target. With this change we only create one or the other.

This user should not be used by applications outside the setup phase;
for example, elife-dashboard creates its own user with
postgres_user.present and from that moment in time it uses that for
databases, schemas and data.

Finally, notice the RDS root user has a different, generated password
with respect to that local Postgres root user.