### PR TITLE
Correct PHP 7 packages

### DIFF
--- a/elife/nginx.sls
+++ b/elife/nginx.sls
@@ -116,23 +116,11 @@ web-ssl-enabled:
 # service
 #
 
-# php in ubuntu 14.04 comes with a transistive dependency on apache2 by default. 
-# when we install php, we don't know if we are going to be using nginx or apache
-# so it installs apache by default if it can't find any other webserver
-# this is an arse, a bug, and the below is a hack.
-kill-me-an-injun:
-    service.dead:
-        - name: apache2
-        - enable: False
-        - onlyif:
-            - which apache2
-
 nginx-server-service:
     service.running:
         - name: nginx
         - require:
             - pkg: nginx-server
-            - service: kill-me-an-injun
         - watch:
             # this might not be doing what I think it's doing:
             # https://github.com/saltstack/salt/issues/24436

--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -13,30 +13,15 @@ php-ppa:
             #- pkgrepo: old-php-ppa
 
 php:
-    cmd.run:
-        # here be dragons:
-        # this is still true for php7.0 :(
-        # https://bugs.launchpad.net/ubuntu/+source/apt/+bug/423071
-        # simply put: there are four possible dependencies and apache is the 
-        # default. if you don't specify any of the others, INSTALLING PHP5 WILL 
-        # INSTALL APACHE2
-        # see: apt-cache show php7.0
-        #
-        # To have these states remain uncoupled and independant of ordering, we 
-        # have to take a hit here and have Ubuntu install apache.
-        - name: |
-            export DEBIAN_FRONTEND=noninteractive 
-            apt-get install -y --force-yes --no-install-recommends \
-                php7.0 \
-                php7.0-mbstring \
-                php7.0-dev \
-                php-pear \
-                php7.0-mysql \
-                php7.0-xsl \
-                php7.0-gd \
-                php7.0-curl \
-                php7.0-mcrypt \
-                libpcre3-dev # pcre for php5 \
+    pkg.installed:
+        - pkgs:
+            - php7.0-cli
+            - php7.0-mbstring
+            - php7.0-mysql
+            - php7.0-xsl
+            - php7.0-gd
+            - php7.0-curl
+            - php7.0-mcrypt
         - require:
             - pkgrepo: php-ppa
             - pkg: base
@@ -92,7 +77,7 @@ install-composer:
             wget -O - https://getcomposer.org/installer | php
             mv composer.phar composer
         - require:
-            - cmd: php
+            - php
             - environ: composer-home
             - composer-auth
         - unless:


### PR DESCRIPTION
Installing `php7.0-cli` rather than `php7.0` is the key to not getting Apache installed.

This also removes a couple of other PHP extensions that we don't need (PEAR and `-dev`).