### PR TITLE
Don't change Composer file modes

### DIFF
--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -54,12 +54,10 @@ composer-home-dir:
         - name: {{ composer_home }}
         - user: {{ pillar.elife.deploy_user.username }}
         - group: {{ pillar.elife.deploy_user.username }}
-        - dir_mode: 775
-        - file_mode: 664
+        - dir_mode: 755
         - recurse:
             - user
             - group
-            - mode
 
 composer-home:
     environ.setenv:

--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -47,7 +47,7 @@ php-cli-config:
 # Composer (php package management)
 #
 
-{% set composer_home = '/etc/composer' %}
+{% set composer_home = '/usr/lib/composer' %}
 
 composer-home-dir:
     file.directory:


### PR DESCRIPTION
Builds such as https://ci--alfred.elifesciences.org/job/test-journal/127/ are failing after a second provision as files modes have been changed, this should fix it.

I've also changed Composer's home directory to @giorgiosironi's suggestion, which also means that existing broken machines don't need to be fixed.