### PR TITLE
Speeding up apt updates

### DIFF
--- a/elife/config/etc-apt-apt.conf.d-50unattended-upgrades
+++ b/elife/config/etc-apt-apt.conf.d-50unattended-upgrades
@@ -56,4 +56,4 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
-Acquire::http::Dl-Limit "70";
+Acquire::http::Dl-Limit "1000";

--- a/elife/config/etc-apt-apt.conf.d-50unattended-upgrades
+++ b/elife/config/etc-apt-apt.conf.d-50unattended-upgrades
@@ -56,4 +56,4 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
-Acquire::http::Dl-Limit "1000";
+// Acquire::http::Dl-Limit "70";


### PR DESCRIPTION
According to the manpage of apt.conf, all files in Dir::Etc::Parts (/etc/apt/apt.conf.d) are included automatically. Therefore the Dl-Limit is applied to all apt-get update commands.

In Vagrant, this change sped up the installation of Jenkins from ~20 minutes to ~60 seconds