### PR TITLE
Proposing to access buildvars with `cfg('build_vars.something')`

### DIFF
--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -125,6 +125,7 @@ def cfg(*paths):
     default = paths[-1] if len(paths) > 1 else None    
     data = {
         'project': read_json('/etc/build-vars.json.b64') or {}, # template 'compile' time data
+        'buildvars': read_json('/etc/build-vars.json.b64') or {}, # template 'compile' time data
         'cfn': cfn() # stack 'creation' time data
     }
     # don't raise exceptions if path value not found. very django-like


### PR DESCRIPTION
Build vars are structured like this:
```
{
    "branch": "...",
    "revision": "...",
    "project": {
        "aws": {
        },
        "vagrant": {
        },
    }
    ...
}
```
We currently access them with `cfg('project.revision')` in the Salt
templates or `elife.py` code.

However, this does not give access to the `project` key, but to the root
fo the build vars. I find this confusing as we may have to write `cfg('project.project.aws')` and `project` is used in two places.

So I propose to access them with `cfg('buildvars.revision')` with the
same pattern as `cfg('cfn.DomainName')` used for CloudFormation outputs.
A long backward compatibility window will be in place since there may be
many formulas relying on `project.`