### PR TITLE
Make daily update not simultaneous inside a cluster

### DIFF
--- a/elife/daily-system-updates.sls
+++ b/elife/daily-system-updates.sls
@@ -17,6 +17,7 @@ daily-system-updates:
     cron.present:
         - identifier: daily-system-update
         - name: /usr/local/bin/daily-system-update
+        # stagger updates to clusters of machines
         {% if salt['elife.cfg']('project.node', 1) % 2 == 1 %}
         # odd server
         - minute: '15'

--- a/elife/daily-system-updates.sls
+++ b/elife/daily-system-updates.sls
@@ -16,9 +16,14 @@ daily-system-update-log-rotater:
 daily-system-updates:
     cron.present:
         - identifier: daily-system-update
-        # salt isn't emitting anything :( this log and logrotation is useless
         - name: /usr/local/bin/daily-system-update
-        - minute: 30
+        {% if salt['elife.cfg']('project.node', 1) % 2 == 1 %}
+        # odd server
+        - minute: '15'
+        {% else %}
+        # even server
+        - minute: '45'
+        {% endif %}
         - hour: 21
         - dayweek: '0-4'
         - require:


### PR DESCRIPTION
When journal or iiif stacks that have more than one server do their updates, they take down nginx and/or other daemons to avoid errors happening during the process.
However, if we have multiple instances they shouldn't all go down at the same time, otherwise the ELB won't have any instance to serve traffic.