### PR TITLE
Smarter HTTPS redirect

### DIFF
--- a/elife/config/etc-nginx-sites-available-unencrypted-redirect.conf
+++ b/elife/config/etc-nginx-sites-available-unencrypted-redirect.conf
@@ -13,6 +13,6 @@ server {
     }
 
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
We should use $host as if a CNAME is used this doesn't redirect to the main, longer hostname.

e.g. http://ui-patterns.elifesciences.org should be https://ui-patterns.elifesciences.org, not https://prod--ui-patterns.elifesciences.org

Just in case something strange happens, this is used by `iiif` and `pattern-library`. The first one should always be accessed in `https` already, and usually through the CDN.