### PR TITLE
UBR MySQL RDS password is wrong

### DIFF
--- a/elife/config/etc-ubr-config
+++ b/elife/config/etc-ubr-config
@@ -5,4 +5,4 @@ AWS_SECRET_ACCESS_KEY={{ pillar.elife.backups.s3_secret }}
 # credentials for accessing MySQL
 # https://dev.mysql.com/doc/refman/5.7/en/environment-variables.html
 MYSQL_USER={{ pillar.elife.db_root.username }}
-MYSQL_PWD={{ pillar.elife.db_root.password }}
+MYSQL_PWD={{ pillar.elife.db_root.password }} # but if RDS is used this is wrong


### PR DESCRIPTION
I don't know if this configuration file is used anymore, but the root password stored here is wrong in case RDS is used (different one, that works, is stored in the build vars).
UBR worked anyway for restoring to a MySQL RDS instance using root, so it must be picking up the configuration from elsewhere. Hence maybe this is not used anymore and should be deleted? Otherwise we fix it.