### PR TITLE
nginx, logrotate, disabled delaycompress

### DIFF
--- a/elife/config/etc-logrotate.d-nginx
+++ b/elife/config/etc-logrotate.d-nginx
@@ -7,7 +7,8 @@
     missingok
     notifempty
     compress
-    delaycompress
+    # disabled. use zcat, zless, etc to view .gz files
+    #delaycompress
     create 0640 www-data adm
     sharedscripts
     prerotate


### PR DESCRIPTION
api-gateway generates several GBs of logs and forcing a rotate doesn't 'solve' the problem

from the man page:
```
       delaycompress
              Postpone  compression of the previous log file to the next rota-
              tion cycle.  This has only effect when used in combination  with
              compress.   It  can be used when some program can not be told to
              close its logfile and thus might continue writing to the  previ-
              ous log file for some time.
```