### PR TITLE
feature: decoupled drush+composer

### DIFF
--- a/elife/composer.sls
+++ b/elife/composer.sls
@@ -1,0 +1,88 @@
+#
+# Composer (php package management)
+#
+
+{% set composer_home = '/usr/lib/composer' %}
+
+composer-home-dir:
+    file.directory:
+        - name: {{ composer_home }}
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - dir_mode: 755
+        - recurse:
+            - user
+            - group
+
+composer-home-dir-cache:
+    file.directory:
+        - name: {{ composer_home }}/cache
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - dir_mode: 755
+        - recurse:
+            - user
+            - group
+
+composer-home:
+    environ.setenv:
+        - name: COMPOSER_HOME
+        - value: {{ composer_home }}
+        - require:
+            - file: composer-home-dir
+    file.managed:
+        - name: /etc/profile.d/composer-home.sh
+        - contents: export COMPOSER_HOME={{ composer_home }}
+        - require:
+            - composer-home-dir
+            - composer-home-dir-cache
+
+# https://getcomposer.org/doc/03-cli.md#composer-auth
+{% if pillar.elife.projects_builder.github_token %}
+composer-auth:
+    builder.environ_setenv_sensitive:
+        - name: COMPOSER_AUTH
+        - value: '{"github-oauth": { "github.com": "{{ pillar.elife.projects_builder.github_token }}" } }'
+{% else %}
+composer-auth:
+    environ.setenv:
+        - name: COMPOSER_AUTH
+        - value: ''
+{% endif %}
+
+install-composer:
+    cmd.run:
+        - cwd: /usr/local/bin/
+        - name: |
+            wget -O - https://getcomposer.org/installer | php
+            mv composer.phar composer
+        - require:
+            - php
+            - composer-home
+            - composer-auth
+        - unless:
+            - which composer
+
+composer-global-paths:
+    file.managed:
+        - name: /etc/profile.d/composer-global-paths.sh
+        - contents: export PATH={{ composer_home }}/vendor/bin:$PATH
+        - require:
+            - file: composer-home-dir
+
+update-composer:
+    cmd.run:
+        - name: composer self-update
+        - onlyif:
+            - which composer
+        - require:
+            - cmd: install-composer
+
+# useful to depend on
+composer:
+    cmd.run:
+        - name: composer --version
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - update-composer
+            - composer-global-paths

--- a/elife/drush.sls
+++ b/elife/drush.sls
@@ -1,13 +1,20 @@
 {% set user = pillar.elife.deploy_user.username %}
 
+remove-old-drush:
+    # Ubuntu 14.04 ships with Drush 5
+    # this avoids any conflict
+    pkg.removed:
+        - name: drush
+
 drush:
-  cmd.run:
-    - user: {{ user }}
-    # 2016-01-08: registry_rebuild doesn't work/exist yet for drush ~8.0
-    #- name: composer global require --no-interaction drush/drush:~7.0\|~8.0
-    - name: composer global require --no-interaction drush/drush:~7.0
-    - require:
-        - composer
+    cmd.run:
+        - user: {{ user }}
+        # 2016-01-08: registry_rebuild doesn't work/exist yet for drush ~8.0
+        #- name: composer global require --no-interaction drush/drush:~7.0\|~8.0
+        - name: composer global require --no-interaction drush/drush:~7.0
+        - require:
+            - remove-old-drush
+            - composer
 
 drush-aliases-folder:
     cmd.run:


### PR DESCRIPTION
added composer as a separate state file. an up-to-date drush has it's own state file, but it's tied to the installation of composer in the php7 state file. this prevents non-php7 projects (crm) from using an updated drush.

this was extracted from the php7 state file and there will be some overlap as project formulas are updated.