### PR TITLE
ssh_access now has a special key 'all' that indicates 'all projects'

### DIFF
--- a/elife/deploy-user.sls
+++ b/elife/deploy-user.sls
@@ -56,7 +56,9 @@ vagrant-user:
 
 # allow
 
-{% for username in ssh.allowed.get(pname, []) %}
+{% set allowed = ssh.allowed.get(pname, []) + ssh.allowed.get("all", []) %}
+
+{% for username in allowed %}
     {% if pillar.elife.ssh_users.has_key(username) %}
 
 {{ pname }}-ssh-access-for-{{ username }}:
@@ -84,7 +86,9 @@ vagrant-user:
 
 # deny
 
-{% for username in ssh.denied.get(pname, []) %}
+{% set denied = ssh.denied.get(pname, []) + ssh.denied.get("all", []) %}
+
+{% for username in denied %}
     {% if pillar.elife.ssh_users.has_key(username) %}
 
 {{ pname }}-ssh-denial-for-{{ username }}:

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -39,11 +39,20 @@ elife:
         also_bootstrap_user: True
         # adds keys to deploy user's `~/.ssh/authorized_keys` file
         allowed:
+            # per-user access to all instances
+            all: []
+
+            # per-user, per-project access
+
             project1:
                 - example-user
 
-        # removes keys. happens after allowing keys
+        # removes keys. happens *after* allowed
         denied:
+            # per-user denied access to all instances
+            all: []
+
+            # per-user, per-project denied access
             project1: 
                 - example-user
 
@@ -105,7 +114,7 @@ elife:
             enabled: False
             host: "logs3.papertrailapp.com"
             port: 48058
-            
+
         tick:
             enabled: False
             influx_host: http://localhost:8086


### PR DESCRIPTION
fairly benign change that introduces support for an `all` key in the `ssh_access` pillar data. there is a similar PR on builder-private to prune the ssh_access user list down.