### PR TITLE
Feature: systemd n processes

### DIFF
--- a/elife/templates/systemd-multiple-processes.sh
+++ b/elife/templates/systemd-multiple-processes.sh
@@ -1,42 +1,42 @@
 #!/bin/bash
 NUMBER={{ number }}
 timeout=120
-    echo "--------"
-    echo "Current status of $NUMBER {{ process }} processes"
-    echo "Now is" $(date -Iseconds)
-    for i in `seq 1 $NUMBER`
-    do
-        systemctl status {{ process }}@$i -n 0 || true
-    done
+echo "--------"
+echo "Current status of $NUMBER {{ process }} processes"
+echo "Now is" $(date -Iseconds)
+for i in `seq 1 $NUMBER`
+do
+    systemctl status {{ process }}@$i -n 0 || true
+done
 
-    echo "Stopping $NUMBER {{ process }} processes"
-    echo "Now is" $(date -Iseconds)
-    for i in `seq 1 $NUMBER`
-    do
-        (systemctl stop {{ process }}@$i &) || true
-    done
+echo "Stopping $NUMBER {{ process }} processes"
+echo "Now is" $(date -Iseconds)
+for i in `seq 1 $NUMBER`
+do
+    (systemctl stop {{ process }}@$i &) || true
+done
 
-    for i in `seq 1 $NUMBER`
+for i in `seq 1 $NUMBER`
+do
+    echo "Waiting for {{ process }} $i to stop"
+    echo "Now is" $(date -Iseconds)
+    counter=0
+    while true
     do
-        echo "Waiting for {{ process }} $i to stop"
-        echo "Now is" $(date -Iseconds)
-        counter=0
-        while true
-        do
-            if [ "$counter" -gt "$timeout" ]
-            then
-                echo "It shouldn't take more than $timeout seconds to kill all the {{ process }} processes"
-                exit 1
-            fi
-            systemctl status {{ process }}@$i -n 0 | grep "Active: inactive" && break
-            sleep 1
-            counter=$((counter + 1))
-        done
+        if [ "$counter" -gt "$timeout" ]
+        then
+            echo "It shouldn't take more than $timeout seconds to kill all the {{ process }} processes"
+            exit 1
+        fi
+        systemctl status {{ process }}@$i -n 0 | grep "Active: inactive" && break
+        sleep 1
+        counter=$((counter + 1))
     done
-    echo "Stopped all {{ process }} processes"
-    echo "Starting $NUMBER {{ process }} processes"
-    for i in `seq 1 $NUMBER`
-    do
-        systemctl start {{ process }}@$i
-    done
-    echo "Started $NUMBER {{ process }} processes"
+done
+echo "Stopped all {{ process }} processes"
+echo "Starting $NUMBER {{ process }} processes"
+for i in `seq 1 $NUMBER`
+do
+    systemctl start {{ process }}@$i
+done
+echo "Started $NUMBER {{ process }} processes"

--- a/elife/templates/systemd-multiple-processes.sh
+++ b/elife/templates/systemd-multiple-processes.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+NUMBER={{ number }}
+timeout=120
+    echo "--------"
+    echo "Current status of $NUMBER {{ process }} processes"
+    echo "Now is" $(date -Iseconds)
+    for i in `seq 1 $NUMBER`
+    do
+        systemctl status {{ process }}@$i -n 0 || true
+    done
+
+    echo "Stopping $NUMBER {{ process }} processes"
+    echo "Now is" $(date -Iseconds)
+    for i in `seq 1 $NUMBER`
+    do
+        (systemctl stop {{ process }}@$i &) || true
+    done
+
+    for i in `seq 1 $NUMBER`
+    do
+        echo "Waiting for {{ process }} $i to stop"
+        echo "Now is" $(date -Iseconds)
+        counter=0
+        while true
+        do
+            if [ "$counter" -gt "$timeout" ]
+            then
+                echo "It shouldn't take more than $timeout seconds to kill all the {{ process }} processes"
+                exit 1
+            fi
+            systemctl status {{ process }}@$i -n 0 | grep "Loaded: not-found" && break
+            sleep 1
+            counter=$((counter + 1))
+        done
+    done
+    echo "Stopped all {{ process }} processes"
+    echo "Starting $NUMBER {{ process }} processes"
+    for i in `seq 1 $NUMBER`
+    do
+        systemctl start {{ process }}@$i
+    done
+    echo "Started $NUMBER {{ process }} processes"

--- a/elife/templates/systemd-multiple-processes.sh
+++ b/elife/templates/systemd-multiple-processes.sh
@@ -28,7 +28,7 @@ timeout=120
                 echo "It shouldn't take more than $timeout seconds to kill all the {{ process }} processes"
                 exit 1
             fi
-            systemctl status {{ process }}@$i -n 0 | grep "Loaded: not-found" && break
+            systemctl status {{ process }}@$i -n 0 | grep "Active: inactive" && break
             sleep 1
             counter=$((counter + 1))
         done


### PR DESCRIPTION
the lax 16.04 branch uses this and it appears to work. there is an unrelated newrelic error in there preventing it from starting but you can load this up for yourself with:

`./bldr masterless.set_versions:lax--mltest2,builder-base-formula@feat-systemd-n-processes,lax-formula@feat-ubuntu-1604`