### PR TITLE
Extracting backup cron

### DIFF
--- a/elife/backups-cron.sls
+++ b/elife/backups-cron.sls
@@ -1,0 +1,15 @@
+# 11pm every day
+daily-backups: 
+    # only backup prod, adhoc and continuumtest instances
+    {% if pillar.elife.env in ['dev', 'ci', 'end2end'] %}
+    cron.absent:
+    {% else %}
+    cron.present:
+    {% endif %}
+        - user: root
+        - identifier: daily-app-backups
+        - name: cd /opt/ubr/ && ./ubr.sh > /var/log/ubr-cron.log
+        - minute: 0
+        - hour: 23
+        - require:
+            - install-ubr

--- a/elife/backups.sls
+++ b/elife/backups.sls
@@ -44,19 +44,3 @@ monitor-backup-logs:
         - require:
             - pkg: syslog-ng
 
-
-# 11pm every day
-daily-backups: 
-    # only backup prod, adhoc and continuumtest instances
-    {% if pillar.elife.env in ['dev', 'ci', 'end2end'] %}
-    cron.absent:
-    {% else %}
-    cron.present:
-    {% endif %}
-        - user: root
-        - identifier: daily-app-backups
-        - name: cd /opt/ubr/ && ./ubr.sh > /var/log/ubr-cron.log
-        - minute: 0
-        - hour: 23
-        - require:
-            - install-ubr

--- a/elife/init.sls
+++ b/elife/init.sls
@@ -10,6 +10,10 @@ include:
     - .deploy-user
     - .time-correction
     - .backups
+    {% if salt['elife.cfg']('project.node', 1) == 1 %}
+    # first server of a cluster
+    - .backups-cron
+    {% else %}
     - .security
     - .logging
     - .upstart-monitoring


### PR DESCRIPTION
Should only be run on the first node of a cluster, as we don't need a database to be backed up multiple times in parallel. I assume that if a stack uses multiple servers, these servers don't have local state to backup as they have moved their state in RDS, S3 or a similar external centralized service.

Other crons, like daily-system-updates or time-correction, can (and should) run safely everywhere.