### PR TITLE
ELPP-3237 wait_packagist cleans selectively Composer's cache

### DIFF
--- a/elife/jenkins-scripts/wait_packagist.sh
+++ b/elife/jenkins-scripts/wait_packagist.sh
@@ -22,3 +22,7 @@ while : ; do
         break
     fi
 done
+
+cache_file_for_package_revisions=~/.cache/composer/repo/https---packagist.org/provider-"${package/\//\$}".json
+echo "Removing $cache_file_for_package_revisions to make sure Composer will see the update."
+rm -f "$cache_file_for_package_revisions"

--- a/elife/jenkins-scripts/wait_packagist.sh
+++ b/elife/jenkins-scripts/wait_packagist.sh
@@ -9,6 +9,7 @@ fi
 
 package="$1"
 revision="$2"
+composer="${COMPOSER_HOME:-$HOME}"
 polling=5
 
 while : ; do
@@ -23,6 +24,6 @@ while : ; do
     fi
 done
 
-cache_file_for_package_revisions=~/.cache/composer/repo/https---packagist.org/provider-"${package/\//\$}".json
+cache_file_for_package_revisions="${composer}/.cache/composer/repo/https---packagist.org/provider-${package/\//\$}".json
 echo "Removing $cache_file_for_package_revisions to make sure Composer will see the update."
 rm -f "$cache_file_for_package_revisions"


### PR DESCRIPTION
The script doesn't use a cache by itself, but it cleans the Composer's relevant cache file so that if subsequent `composer` commands are issued they will see the same version of the package rather then an old one.