### PR TITLE
Add WebP content type to Nginx

### DIFF
--- a/elife/config/etc-nginx-nginx.conf
+++ b/elife/config/etc-nginx-nginx.conf
@@ -30,6 +30,12 @@ http {
 
 	include /etc/nginx/mime.types;
 	types {
+		application/javascript js;
+		application/rss+xml rss;
+
+		font/woff woff;
+		font/woff2 woff2;
+
 		image/webp webp;
 	}
 	default_type application/octet-stream;

--- a/elife/config/etc-nginx-nginx.conf
+++ b/elife/config/etc-nginx-nginx.conf
@@ -29,6 +29,9 @@ http {
 	# server_name_in_redirect off;
 
 	include /etc/nginx/mime.types;
+	types {
+		image/webp webp;
+	}
 	default_type application/octet-stream;
 
 	##


### PR DESCRIPTION
Currently serving them as `application/octet-stream` (browsers render them in a page, but download if you go direct to the image).

Alternatively we could replace `mime.types` with something like https://github.com/h5bp/server-configs-nginx/blob/master/mime.types.