### PR TITLE
update_python_dependency script

### DIFF
--- a/elife/utils/update_python_dependency
+++ b/elife/utils/update_python_dependency
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 PACKAGE_NAME REMOTE"
+    echo "Example: $0 elife-tools https://github.com/elifesciences/elife-tools.git"
+    echo "Execute inside your virtualenv"
+    exit 1
+fi
+
+name="$1"
+remote="$2"
+clone_folder="/tmp/${name}-shallow-clone"
+rm -rf "$clone_folder"
+git clone --depth 1 "$remote" "$clone_folder"
+cd "$clone_folder"
+# this uses the default branch, which may be `develop` or `master`
+dependency_sha1=$(git rev-parse HEAD)
+cd - 1>&2
+sed -i -e "s;.*${remote}.*;git+${remote}@${dependency_sha1}#egg=${name};g" requirements.txt
+pip uninstall -y "$name" 1>&2
+pip install -r requirements.txt 1>&2
+echo "pinned $name in requirements.txt to $dependency_sha1"


### PR DESCRIPTION
Useful in builds that open pull requests for updating a dependency (usually a Pip-installed package).

Sample output when used on `elife-bot`:
```
(venv) [14:55:51][giorgio@Newton:~/code/elife-bot]$ ~/code/builder/cloned-projects/builder-base-formula/elife/utils/update_python_dependency elifetools https://github.com/elifesciences/elife-tools.git
Cloning into '/tmp/elifetools-shallow-clone'...
remote: Counting objects: 1218, done.
remote: Compressing objects: 100% (517/517), done.
remote: Total 1218 (delta 351), reused 1092 (delta 291), pack-reused 0
Receiving objects: 100% (1218/1218), 1.91 MiB | 452.00 KiB/s, done.
Resolving deltas: 100% (351/351), done.
Checking connectivity... done.
/home/giorgio/code/elife-bot
Uninstalling elifetools-0.1.7:
  Successfully uninstalled elifetools-0.1.7
Requirement already satisfied: boto==2.48.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 1))
Requirement already satisfied: Fom==0.9.10 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 2))
Requirement already satisfied: GitPython==0.3.2.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 3))
Requirement already satisfied: Jinja2==2.7.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 4))
Requirement already satisfied: PyPDF2==1.23 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 5))
Requirement already satisfied: arrow==0.4.4 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 6))
Requirement already satisfied: beautifulsoup4==4.3.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 7))
Requirement already satisfied: lettuce==0.2.20 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 8))
Requirement already satisfied: requests==2.5.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 9))
Requirement already satisfied: wsgiref==0.1.2 in /usr/lib/python2.7 (from -r requirements.txt (line 10))
Requirement already satisfied: lxml==3.4.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 11))
Requirement already satisfied: xlrd==0.9.3 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 12))
Collecting elifetools from git+https://github.com/elifesciences/elife-tools.git@1e6682548dd41e5168ff886d01163ccb12c78ce3#egg=elifetools (from -r requirements.txt (line 13))
  Cloning https://github.com/elifesciences/elife-tools.git (to 1e6682548dd41e5168ff886d01163ccb12c78ce3) to /tmp/user/1001/pip-build-gXRQVY/elifetools
  Could not find a tag or branch '1e6682548dd41e5168ff886d01163ccb12c78ce3', assuming commit.
Requirement already satisfied: elifearticle from git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 14))
Requirement already satisfied: elifecrossref from git+https://github.com/elifesciences/elife-crossref-xml-generation.git@a6d011ec3c3f3803b135fe1c991a187c23e70fbd#egg=elifecrossref in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 15))
Requirement already satisfied: PyYAML==3.11 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 16))
Requirement already satisfied: Wand==0.4.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 17))
Requirement already satisfied: paramiko==1.15.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 18))
Requirement already satisfied: mock==1.3.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 19))
Requirement already satisfied: redis==2.10.5 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 20))
Requirement already satisfied: testfixtures==4.9.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 21))
Requirement already satisfied: pytest==2.9.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 22))
Requirement already satisfied: ddt==1.1.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 23))
Requirement already satisfied: Pillow==3.2.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 24))
Obtaining jats-scraper from git+https://github.com/elifesciences/jats-scraper.git#egg=jats-scraper (from -r requirements.txt (line 25))
  Updating ./venv/src/jats-scraper clone
  Running setup.py (path:/home/giorgio/code/elife-bot/venv/src/jats-scraper/setup.py) egg_info for package jats-scraper produced metadata for project name unknown. Fix your #egg=jats-scraper fragments.
Obtaining scraper from hg+https://bitbucket.org/lskibinski/scraper#egg=scraper (from -r requirements.txt (line 26))
  Updating ./venv/src/scraper clone
Requirement already satisfied: ndg-httpsclient==0.4.2 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 27))
Requirement already satisfied: pyasn1==0.1.9 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 28))
Requirement already satisfied: pyOpenSSL==16.2.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 29))
Requirement already satisfied: newrelic==2.72.0.52 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 30))
Requirement already satisfied: pylint==1.6.4 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 31))
Requirement already satisfied: pyGithub==1.27.1 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 32))
Requirement already satisfied: pyFunctional==1.0.0 in ./venv/lib/python2.7/site-packages (from -r requirements.txt (line 33))
Requirement already satisfied: blinker in ./venv/lib/python2.7/site-packages (from Fom==0.9.10->-r requirements.txt (line 2))
Requirement already satisfied: gitdb>=0.6.0 in ./venv/lib/python2.7/site-packages (from GitPython==0.3.2.1->-r requirements.txt (line 3))
Requirement already satisfied: markupsafe in ./venv/lib/python2.7/site-packages (from Jinja2==2.7.3->-r requirements.txt (line 4))
Requirement already satisfied: python-dateutil in ./venv/lib/python2.7/site-packages (from arrow==0.4.4->-r requirements.txt (line 6))
Requirement already satisfied: fuzzywuzzy in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: sure in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: python-subunit in ./venv/lib/python2.7/site-packages (from lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: slugify==0.0.1 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: unittest-xml-reporting==1.12.0 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: coverage==3.7.1 in ./venv/lib/python2.7/site-packages (from elifetools->-r requirements.txt (line 13))
Requirement already satisfied: configparser in ./venv/lib/python2.7/site-packages (from elifecrossref->-r requirements.txt (line 15))
Requirement already satisfied: pycrypto!=2.4,>=2.1 in ./venv/lib/python2.7/site-packages (from paramiko==1.15.2->-r requirements.txt (line 18))
Requirement already satisfied: ecdsa>=0.11 in ./venv/lib/python2.7/site-packages (from paramiko==1.15.2->-r requirements.txt (line 18))
Requirement already satisfied: six>=1.7 in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: funcsigs; python_version < "3.3" in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: pbr>=0.11 in ./venv/lib/python2.7/site-packages (from mock==1.3.0->-r requirements.txt (line 19))
Requirement already satisfied: py>=1.4.29 in ./venv/lib/python2.7/site-packages (from pytest==2.9.1->-r requirements.txt (line 22))
Requirement already satisfied: pytz==2015.4 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: deepdiff==0.5.9 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: jmespath==0.9.0 in ./venv/lib/python2.7/site-packages (from unknown->-r requirements.txt (line 25))
Requirement already satisfied: cryptography>=1.3.4 in ./venv/lib/python2.7/site-packages (from pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: astroid<1.5.0,>=1.4.5 in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: backports.functools-lru-cache; python_version == "2.7" in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: mccabe in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: isort>=4.2.5 in ./venv/lib/python2.7/site-packages (from pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: dill==0.2.5 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: tabulate==0.7.7 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: future==0.16.0 in ./venv/lib/python2.7/site-packages (from pyFunctional==1.0.0->-r requirements.txt (line 33))
Requirement already satisfied: smmap>=0.8.5 in ./venv/lib/python2.7/site-packages (from gitdb>=0.6.0->GitPython==0.3.2.1->-r requirements.txt (line 3))
Requirement already satisfied: extras in ./venv/lib/python2.7/site-packages (from python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: testtools>=0.9.34 in ./venv/lib/python2.7/site-packages (from python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: idna>=2.0 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: ipaddress in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: enum34 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: cffi>=1.4.1 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: setuptools>=11.3 in ./venv/lib/python2.7/site-packages (from cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Requirement already satisfied: lazy-object-proxy in ./venv/lib/python2.7/site-packages (from astroid<1.5.0,>=1.4.5->pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: wrapt in ./venv/lib/python2.7/site-packages (from astroid<1.5.0,>=1.4.5->pylint==1.6.4->-r requirements.txt (line 31))
Requirement already satisfied: python-mimeparse in ./venv/lib/python2.7/site-packages (from testtools>=0.9.34->python-subunit->lettuce==0.2.20->-r requirements.txt (line 8))
Requirement already satisfied: pycparser in ./venv/lib/python2.7/site-packages (from cffi>=1.4.1->cryptography>=1.3.4->pyOpenSSL==16.2.0->-r requirements.txt (line 29))
Installing collected packages: elifetools, unknown, scraper
  Running setup.py install for elifetools ... done
  Found existing installation: UNKNOWN 2015.5.28
    Uninstalling UNKNOWN-2015.5.28:
      Successfully uninstalled UNKNOWN-2015.5.28
  Running setup.py develop for unknown
  Found existing installation: scraper 0.1
    Uninstalling scraper-0.1:
      Successfully uninstalled scraper-0.1
  Running setup.py develop for scraper
Successfully installed elifetools-0.1.7 scraper unknown
pinned elifetools in requirements.txt to 1e6682548dd41e5168ff886d01163ccb12c78ce3
```

Produces the diff:
```

diff --git a/requirements.txt b/requirements.txt
index 99107f4..0286692 100644
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests==2.5.3
 wsgiref==0.1.2
 lxml==3.4.1
 xlrd==0.9.3
-git+https://github.com/elifesciences/elife-tools.git@7fbcef83fbe4ff960a6f44e1d143588b96c79325#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@1e6682548dd41e5168ff886d01163ccb12c78ce3#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle
 git+https://github.com/elifesciences/elife-crossref-xml-generation.git@a6d011ec3c3f3803b135fe1c991a187c23e70fbd#egg=elifecrossref
 PyYAML==3.11
```