### PR TITLE
Generic grep for restarting processes

### DIFF
--- a/elife/config/etc-init-multiple-processes-parallel.conf
+++ b/elife/config/etc-init-multiple-processes-parallel.conf
@@ -32,7 +32,7 @@ script
                 echo "It shouldn't take more than $timeout seconds to kill all the {{ process }} processes"
                 exit 1
             fi
-            status {{ process }} ID=$i 2>&1 | grep "Unknown instance" && break
+            status {{ process }} ID=$i 2>&1 | grep "Unknown " && break
             sleep 1
             counter=$((counter + 1))
         done


### PR DESCRIPTION
Usually we encounter `Unknown instance`, but if it's the first time we deploy processes we may see `Unknown job`