### PR TITLE
Support PHP long-running processes in 16.04

### DIFF
--- a/elife/config/lib-systemd-system-php-service.service
+++ b/elife/config/lib-systemd-system-php-service.service
@@ -14,4 +14,4 @@ User={{ pillar.elife.deploy_user.username }}
 ExecStart={{ command }}
 # restart even if exits cleanly (e.g. memory limit reached)
 Restart=always
-RestartSec=10
+RestartSec=5

--- a/elife/config/lib-systemd-system-php-service.service
+++ b/elife/config/lib-systemd-system-php-service.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="PHP long-running process {{ name }}"
+Requires=network.target
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ folder }}
+Environment="ENVIRONMENT_NAME={{ pillar.elife.env }}"
+User={{ pillar.elife.deploy_user.username }}
+ExecStart={{ command }}
+# restart even if exits cleanly (e.g. memory limit reached)
+Restart=always
+RestartSec=10

--- a/elife/config/lib-systemd-system-php-service.service
+++ b/elife/config/lib-systemd-system-php-service.service
@@ -1,5 +1,5 @@
 [Unit]
-Description="PHP long-running process {{ name }}"
+Description="PHP long-running process {{ name }} %I"
 Requires=network.target
 After=network.target
 

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -15,7 +15,9 @@ php-long-running-process-service-{{ hyphenized }}:
             command: {{ configuration.command }}
         - require:
             - php
-            # TODO: add optional require
+            {% if configuration.get('require', None) -%}
+            - {{ configuration.get('require') }}
+            {%- endif %}
         - require_in:
             - cmd: php-long-running-processes-load-configuration
 {% endfor %}

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -30,7 +30,7 @@ php-long-running-processes-load-configuration:
 {% set hyphenized = name | replace('_', '-') %}
 {% set service_name = salt['elife.project_name']() + '-' + hyphenized %}
 {% for i in range(1, configuration['number'] + 1) %}
-php-long-running-process-service-{{ hyphenized }}-{{ i }}-start:
+php-long-running-process-service-{{ hyphenized }}-{{ i }}-enable:
     cmd.run:
         - name: systemctl enable {{ service_name }}@{{ i }}
         - require:
@@ -44,6 +44,4 @@ php-long-running-process-service-{{ hyphenized }}-parallel-restart:
     cmd.run:
         - name: systemctl restart {{ service_name }}@{1..{{ configuration['number'] }}}
 {% endfor %}
-
-    
 {% endif %}

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -27,9 +27,8 @@ php-long-running-processes-load-configuration:
 {% for name, configuration in pillar.elife.php.processes.configuration.items() %}
 {% set hyphenized = name | replace("_", "-") %}
 {% set service_name = salt['elife.project_name']() + "-" + hyphenized %}
-# TODO: add counter and instance numbers
 # TODO: " vs '
-{% for i in range(0, configuration['number']) %}
+{% for i in range(1, configuration['number'] + 1) %}
 php-long-running-process-service-{{ hyphenized }}-{{ i }}-start:
     cmd.run:
         - name: systemctl enable {{ service_name }}@{{ i }}

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -2,8 +2,8 @@
 
 {% if pillar.elife.php.processes.enabled %}
 {% for name, configuration in pillar.elife.php.processes.configuration.items() %}
-{% set hyphenized = name | replace("_", "-") %}
-{% set service_name = salt['elife.project_name']() + "-" + hyphenized %}
+{% set hyphenized = name | replace('_', '-') %}
+{% set service_name = salt['elife.project_name']() + '-' + hyphenized %}
 php-long-running-process-service-{{ hyphenized }}:
     file.managed:
         - name: /lib/systemd/system/{{ service_name }}@.service
@@ -25,9 +25,8 @@ php-long-running-processes-load-configuration:
         - name: systemctl daemon-reload
 
 {% for name, configuration in pillar.elife.php.processes.configuration.items() %}
-{% set hyphenized = name | replace("_", "-") %}
-{% set service_name = salt['elife.project_name']() + "-" + hyphenized %}
-# TODO: " vs '
+{% set hyphenized = name | replace('_', '-') %}
+{% set service_name = salt['elife.project_name']() + '-' + hyphenized %}
 {% for i in range(1, configuration['number'] + 1) %}
 php-long-running-process-service-{{ hyphenized }}-{{ i }}-start:
     cmd.run:

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -1,13 +1,16 @@
 # only supports 16.04!
 
-{% for name, configuration in pillar.elife.php.processes.items() %}
+{% if pillar.elife.php.processes.enabled %}
+{% for name, configuration in pillar.elife.php.processes.configuration.items() %}
+{% set hyphenized = name | replace("_", "-") %}
+{% set service_name = salt['elife.project_name']() + "-" + hyphenized %}
 php-long-running-process-service-{{ name }}:
     file.managed:
-        - name: /lib/systemd/system/{{ salt['elife.project_name']() }}-{{ name }}.service
+        - name: /lib/systemd/system/{{ service_name }}@.service
         - source: salt://elife/config/lib-systemd-system-php-service.service
         - template: jinja
         - context:
-            name: {{ name }}
+            name: {{ hyphenized }}
             folder: {{ configuration.folder }}
             command: {{ configuration.command }}
         - require:
@@ -19,3 +22,38 @@ php-long-running-process-service-{{ name }}:
 php-long-running-processes:
     cmd.run:
         - name: systemctl daemon-reload
+
+{% for name, configuration in pillar.elife.php.processes.configuration.items() %}
+{% set hyphenized = name | replace("_", "-") %}
+{% set service_name = salt['elife.project_name']() + "-" + hyphenized %}
+# TODO: add counter and instance numbers
+# TODO: " vs '
+{% for i in range(0, configuration['number']) %}
+php-long-running-process-service-{{ name }}-{{ i }}-start:
+    cmd.run:
+        - name: systemctl enable {{ service_name }}@{{ i }}
+        - require:
+            - php-long-running-process-service-{{ name }}
+        - require_in:
+            - file: php-long-running-process-service-{{ name }}-parallel-restart
+{% endfor %}
+
+# TODO: this could be a single command for all kinds of processes
+php-long-running-process-service-{{ name }}-parallel-restart:
+    file.managed:
+        - name: /usr/local/bin/php-long-running-processes-{{ name }}-restart
+        - template: salt://elife/templates/systemd-multiple-processes.sh
+        - mode: 544
+        - context:
+            process: {{ service_name }}
+            number: {{ configuration['number'] }}
+
+    cmd.run:
+        - name: php-long-running-processes-{{ name }}-restart
+        - require:
+            - file: php-long-running-process-service-{{ name }}-parallel-restart
+
+{% endfor %}
+
+    
+{% endif %}

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -1,0 +1,21 @@
+# only supports 16.04!
+
+{% for name, configuration in pillar.elife.php.processes.items() %}
+php-long-running-process-service-{{ name }}:
+    file.managed:
+        - name: /lib/systemd/system/{{ salt['elife.project_name']() }}-{{ name }}.service
+        - source: salt://elife/config/lib-systemd-system-php-service.service
+        - template: jinja
+        - context:
+            name: {{ name }}
+            folder: {{ configuration.folder }}
+            command: {{ configuration.command }}
+        - require:
+            - php
+        - require_in:
+            - cmd: php-long-running-processes
+{% endfor %}
+
+php-long-running-processes:
+    cmd.run:
+        - name: systemctl daemon-reload

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -32,7 +32,6 @@ php-long-running-processes-load-configuration:
 {% for i in range(0, configuration['number']) %}
 php-long-running-process-service-{{ hyphenized }}-{{ i }}-start:
     cmd.run:
-        # TODO: does this make them come up on boot?
         - name: systemctl enable {{ service_name }}@{{ i }}
         - require:
             - php-long-running-process-service-{{ hyphenized }}

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -41,20 +41,8 @@ php-long-running-process-service-{{ hyphenized }}-{{ i }}-start:
 
 # TODO: this could be a single command for all kinds of processes
 php-long-running-process-service-{{ hyphenized }}-parallel-restart:
-    file.managed:
-        - name: /usr/local/bin/php-long-running-processes-{{ hyphenized }}-restart
-        - source: salt://elife/templates/systemd-multiple-processes.sh
-        - template: jinja
-        - mode: 544
-        - context:
-            process: {{ service_name }}
-            number: {{ configuration['number'] }}
-
     cmd.run:
-        - name: php-long-running-processes-{{ hyphenized }}-restart
-        - require:
-            - file: php-long-running-process-service-{{ hyphenized }}-parallel-restart
-
+        - name: systemctl restart {{ service_name }}@{1..{{ configuration['number'] }}}
 {% endfor %}
 
     

--- a/elife/php-long-running-processes.sls
+++ b/elife/php-long-running-processes.sls
@@ -4,7 +4,7 @@
 {% for name, configuration in pillar.elife.php.processes.configuration.items() %}
 {% set hyphenized = name | replace('_', '-') %}
 {% set service_name = salt['elife.project_name']() + '-' + hyphenized %}
-php-long-running-process-service-{{ hyphenized }}:
+service-{{ hyphenized }}:
     file.managed:
         - name: /lib/systemd/system/{{ service_name }}@.service
         - source: salt://elife/config/lib-systemd-system-php-service.service
@@ -19,10 +19,10 @@ php-long-running-process-service-{{ hyphenized }}:
             - {{ configuration.get('require') }}
             {%- endif %}
         - require_in:
-            - cmd: php-long-running-processes-load-configuration
+            - cmd: service-reload-configurations
 {% endfor %}
 
-php-long-running-processes-load-configuration:
+service-reload-configurations:
     cmd.run:
         - name: systemctl daemon-reload
 
@@ -30,17 +30,17 @@ php-long-running-processes-load-configuration:
 {% set hyphenized = name | replace('_', '-') %}
 {% set service_name = salt['elife.project_name']() + '-' + hyphenized %}
 {% for i in range(1, configuration['number'] + 1) %}
-php-long-running-process-service-{{ hyphenized }}-{{ i }}-enable:
+service-{{ hyphenized }}-{{ i }}-enable:
     cmd.run:
         - name: systemctl enable {{ service_name }}@{{ i }}
         - require:
-            - php-long-running-process-service-{{ hyphenized }}
+            - service-{{ hyphenized }}
         - require_in:
-            - file: php-long-running-process-service-{{ hyphenized }}-parallel-restart
+            - file: service-{{ hyphenized }}-parallel-restart
 {% endfor %}
 
 # TODO: this could be a single command for all kinds of processes
-php-long-running-process-service-{{ hyphenized }}-parallel-restart:
+service-{{ hyphenized }}-parallel-restart:
     cmd.run:
         - name: systemctl restart {{ service_name }}@{1..{{ configuration['number'] }}}
 {% endfor %}

--- a/elife/templates/systemd-multiple-processes.sh
+++ b/elife/templates/systemd-multiple-processes.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# deprecated: use `systemctl restart process@{1..N}`
+
 NUMBER={{ number }}
 timeout=120
 echo "--------"

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -172,8 +172,7 @@ elife:
         upload_max_filesize: 2M
         post_max_size: 8M
         processes:
-            enabled: True
-            #enabled: False
+            enabled: False
             configuration: {}
                 #annotations:
                 #    folder: /srv/annotations

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -171,10 +171,14 @@ elife:
         memory_limit: 64M
         upload_max_filesize: 2M
         post_max_size: 8M
-        processes: {}
-            #annotations:
-            #    folder: /srv/annotations
-            #    command: php bin/console queue:watch
+        processes:
+            enabled: True
+            #enabled: False
+            configuration: {}
+                #annotations:
+                #    folder: /srv/annotations
+                #    command: /srv/annotations/bin/console queue:watch
+                #    number: 1
 
     uwsgi:
         services: {}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -171,6 +171,10 @@ elife:
         memory_limit: 64M
         upload_max_filesize: 2M
         post_max_size: 8M
+        processes: {}
+            #annotations:
+            #    folder: /srv/annotations
+            #    command: php bin/console queue:watch
 
     uwsgi:
         services: {}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -179,6 +179,7 @@ elife:
                 #    folder: /srv/annotations
                 #    command: /srv/annotations/bin/console queue:watch
                 #    number: 1
+                #    [require: some-state]
 
     uwsgi:
         services: {}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -174,7 +174,7 @@ elife:
         processes:
             enabled: False
             configuration: {}
-                #annotations:
+                #queue_watch:
                 #    folder: /srv/annotations
                 #    command: /srv/annotations/bin/console queue:watch
                 #    number: 1


### PR DESCRIPTION
Purely through pillar configuration, since we are already tired of creating systemd service files.

I think this can be extended to Python (or generic) processes later, but with customization of the template to allow for things like New Relic coreography or custom options, so not trivial.