### PR TITLE
Allocate Docker images on external volume if possible

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -4,6 +4,33 @@
 #        - name: |
 #            sudo apt-get -y install linux-image-extra-$(uname -r) linux-image-extra-virtual
 
+docker-folder:
+    file.directory:
+        - name: /ext/docker
+        - makedirs: True
+        - mode: 711
+    
+docker-folder-linking:
+    cmd.run:
+        - name: |
+            sudo /etc/init.d/docker stop || true
+            mv /var/lib/docker/* /ext/docker
+            rmdir /var/lib/docker
+        - onlyif:
+            # has something in it to move
+            - ls -l /var/lib/docker/ | grep -v 'total 0'
+            # is not a symlink already
+            - test ! -L /var/lib/docker
+        - require:
+            - docker-folder
+
+    file.symlink:
+        - name: /var/lib/docker
+        - target: /ext/docker
+        - force: True
+        - require:
+            - cmd: docker-folder-linking
+
 docker-gpg-key:
     cmd.run:
         - name: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -13,6 +40,7 @@ docker-repository:
         - name: sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         - require:
             - docker-gpg-key
+            - docker-folder-linking
 
 docker-packages:
     pkg.installed:
@@ -21,6 +49,11 @@ docker-packages:
         - refresh: True
         - require:
             - docker-repository
+
+    service.running:
+        - name: docker
+        - require:
+            - pkg: docker-packages
 
 docker-compose:
     file.managed:

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -13,7 +13,10 @@ docker-folder:
 docker-folder-linking:
     cmd.run:
         - name: |
-            sudo /etc/init.d/docker stop || true
+            # to be compatible with both upstart and systemd
+            stop docker || true
+            systemctl stop docker || true
+            # move files onto the volume
             mv /var/lib/docker/* /ext/docker
             rmdir /var/lib/docker
         - onlyif:


### PR DESCRIPTION
/ext is sometimes on an external volume, which greatly helps with disk space