### PR TITLE
Pin Composer version temporarily

### DIFF
--- a/elife/composer.sls
+++ b/elife/composer.sls
@@ -79,11 +79,14 @@ composer-global-paths:
 
 update-composer:
     cmd.run:
-        - name: composer self-update
-        - onlyif:
-            - which composer
-        - require_in:
+        - name: composer self-update 1.5.2
+        - require:
             - cmd: install-composer
+        #- name: composer self-update
+        #- onlyif:
+        #    - which composer
+        #- require_in:
+        #    - cmd: install-composer
 
 # useful to depend on
 composer:
@@ -92,4 +95,5 @@ composer:
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - install-composer
+            - update-composer
             - composer-global-paths


### PR DESCRIPTION
Composer 1.5.3 seems to have a problem executing https://github.com/elifesciences/builder-base-formula/blob/688ff004ce22ce3e1b8d0ca53d6ee9f59484bedc/elife/proofreader-php.sls#L1-L6

I've opened https://github.com/composer/composer/issues/6860, but temporarily we can pin the version to the previous release which works.