### PR TITLE
Revert "Pin Composer version temporarily"

### DIFF
--- a/elife/composer.sls
+++ b/elife/composer.sls
@@ -79,14 +79,11 @@ composer-global-paths:
 
 update-composer:
     cmd.run:
-        - name: composer self-update 1.5.2
-        - require:
+        - name: composer self-update
+        - onlyif:
+            - which composer
+        - require_in:
             - cmd: install-composer
-        #- name: composer self-update
-        #- onlyif:
-        #    - which composer
-        #- require_in:
-        #    - cmd: install-composer
 
 # useful to depend on
 composer:
@@ -95,5 +92,4 @@ composer:
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - install-composer
-            - update-composer
             - composer-global-paths


### PR DESCRIPTION
Reverts elifesciences/builder-base-formula#91

Composer 1.5.5 fixes the problem (1.5.4 was released, but didn't work).