### PR TITLE
ELPP-3213 Added daily-security-update

### DIFF
--- a/elife/config/usr-local-bin-daily-security-update
+++ b/elife/config/usr-local-bin-daily-security-update
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e # everything must pass
+set -u # no unbound variables
+
+if [ ! -e "/root/updated-$(date -I)" ]; then
+    run-parts /etc/cron.daily
+    touch "/root/updated-$(date -I)"
+fi

--- a/elife/config/usr-local-bin-daily-security-update
+++ b/elife/config/usr-local-bin-daily-security-update
@@ -2,7 +2,13 @@
 set -e # everything must pass
 set -u # no unbound variables
 
-if [ ! -e "/root/updated-$(date -I)" ]; then
-    run-parts /etc/cron.daily
-    touch "/root/updated-$(date -I)"
+current_date=$(date -I)
+created_file="/root/updated-${current_date}"
+
+if [ -e "${created_file}" ]; then
+    echo "Already run: ${created_file}"
+    exit 0
 fi
+
+run-parts /etc/cron.daily
+touch "${created_file}"

--- a/elife/config/usr-local-bin-daily-system-update
+++ b/elife/config/usr-local-bin-daily-system-update
@@ -2,6 +2,14 @@
 set -e # everything must pass
 set -u # no unbound variables
 
+current_date=$(date -I)
+created_file="/root/highstate-${current_date}"
+
+if [ -e "${created_file}" ]; then
+    echo "Already run: ${created_file}"
+    exit 0
+fi
+
 log_file=/var/log/daily-system-update.log
 set -o pipefail
 sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee $log_file || {
@@ -10,4 +18,5 @@ sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee
     logger "Salt highstate failure: $log_file on $(hostname)"
     exit $status
 }
+touch "${created_file}"
 

--- a/elife/daily-system-updates.sls
+++ b/elife/daily-system-updates.sls
@@ -7,6 +7,12 @@ daily-system-update-command:
         - source: salt://elife/config/usr-local-bin-daily-system-update
         - mode: 544
 
+daily-security-updates-command:
+    file.managed:
+        - name: /usr/local/bin/daily-security-update
+        - source: salt://elife/config/usr-local-bin-daily-security-update
+        - mode: 544
+
 daily-system-update-log-rotater:
     file.managed:
         - name: /etc/logrotate.d/daily-system-update
@@ -34,3 +40,4 @@ daily-system-updates:
        # don't update vagrant machines
         - onlyif:
             - test ! -d /vagrant
+


### PR DESCRIPTION
Like `daily-system-update`, runs a command once daily and no more. Targets apt-get upgrades, logrotate and similar crons. Perhaps needs a better name in the future.