### PR TITLE
[wip] installs and configures pgbouncer.

### DIFF
--- a/elife/config/etc-pgbouncer-pgbouncer.ini
+++ b/elife/config/etc-pgbouncer-pgbouncer.ini
@@ -1,0 +1,13 @@
+# https://pgbouncer.github.io/config.html
+
+[databases]
+{{ db_name }} = host={{ host }} dbname={{ db_name }} user={{ app_user }} password={{ app_pass }}
+
+[pgbouncer]
+pool_mode = session
+listen_addr = {{ pillar.elife.postgresql.pool.host }}
+listen_port = {{ pillar.elife.postgresql.pool.port }}
+auth_type = md5
+auth_file = users.txt
+logfile = /var/log/postgresql/pgbouncer.log
+pidfile = /var/run/postgresql/pgbouncer.pid

--- a/elife/config/lib-systemd-system-pgbouncer.service
+++ b/elife/config/lib-systemd-system-pgbouncer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=pg_bouncer
+After=network.target
+
+[Service]
+User=postgres
+ExecStart=/usr/sbin/pgbouncer /etc/pgbouncer/pgbouncer.ini
+ExecReload=/usr/sbin/pgbouncer -R /etc/pgbouncer/pgbouncer.ini
+
+[Install]
+WantedBy=multi-user.target

--- a/elife/postgresql-appdb.sls
+++ b/elife/postgresql-appdb.sls
@@ -63,3 +63,37 @@ psql-app-db:
         - require:
             - postgres_database: psql-app-db
 
+install-pgbouncer:
+    pkg.installed:
+        - name: pgbouncer
+
+configure-pgbouncer:
+    file.managed:
+        - name: /etc/pgbouncer/pgbouncer.ini
+        - source: salt://elife/config/etc-pgbouncer-pgbouncer.ini
+        - template: jinja
+        - defaults:
+            user: {{ user }}
+            pass: {{ pass }}
+            host: {{ host }}
+            port: {{ port }}
+
+            db_name: {{ db_name }}
+            app_user: {{ app_user_name }}
+            app_pass: {{ app_user_pass }}
+
+pgbouncer-systemd:
+    file.managed:
+        - name: /lib/systemd/system/pgbouncer.service
+        - source: salt://elife/config/lib-systemd-system-pgbouncer.service
+        - template: jinja
+
+pgbouncer:
+    service.running:
+        - enable: True
+        - reload: True
+        - require:
+            - configure-pgbouncer
+            - pgbouncer-systemd
+        - watch:
+            - configure-pgbouncer

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -101,6 +101,10 @@ elife:
         host: '127.0.0.1'
         port: 5432
 
+        pool: # pg_bouncer
+            host: '127.0.0.1'
+            port: 6543
+
     redis:
         host: 127.0.0.1
         port: 6379


### PR DESCRIPTION
* configuration is at pillar.elife.postgresql.pool

With pgbouncer as the connection pooling proxy, all apps using the postgresql-appdb state could be switched over to use it by having `pillar.elife.postgresql.host` and `port` point to localhost (pgbouncer)

connection pooling will reduce the connection overhead in all django applications. flask/other apps using postgresql may also benefit.

pinging @giorgiosironi for thoughts.