### PR TITLE
ELPP-3213 Reduce apt sleep time

### DIFF
--- a/elife/config/etc-apt-apt.conf.d-10periodic
+++ b/elife/config/etc-apt-apt.conf.d-10periodic
@@ -2,3 +2,4 @@ APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
 APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::RandomSleep "30";


### PR DESCRIPTION
https://help.ubuntu.com/community/AutomaticSecurityUpdates describes how `APT::Periodic::RandomSleep` (default up to 1800 seconds) delays updates to spread load evenly during the day. However, we run this manually now, so it is not necessary to distribute the load randomly.