### PR TITLE
ELPP-3213 Disable security update cron when managed externally

### DIFF
--- a/elife/daily-system-updates.sls
+++ b/elife/daily-system-updates.sls
@@ -18,7 +18,6 @@ daily-system-update-log-rotater:
         - name: /etc/logrotate.d/daily-system-update
         - source: salt://elife/config/etc-logrotate.d-daily-system-update
 
-# every weekday at 10:30am UTC
 daily-system-updates:
     {% if not pillar.elife.env in ['ci', 'end2end'] %}
     cron.present:
@@ -46,4 +45,12 @@ daily-system-updates:
         - identifier: daily-system-update
         - name: /usr/local/bin/daily-system-update
     {% endif %}
+
+
+{% if pillar.elife.env in ['ci', 'end2end'] %}
+# managed through Alfred
+daily-security-updates-cron-disable:
+    file.absent:
+        - name: /etc/cron.daily/apt-compat
+{% endif %}
 


### PR DESCRIPTION
In these environments, we are running https://alfred.elifesciences.org/blue/organizations/jenkins/process-daily-updates/activity and the two clash