### PR TITLE
replaced a (very old) postfix prod instance check with preferred method

### DIFF
--- a/elife/postfix.sls
+++ b/elife/postfix.sls
@@ -5,9 +5,8 @@ postfix-mailserver:
             - mailutils # gives us the 'mail' command
 
     # mailserver only runs in production env to prevent accidental mailouts
-    {% if salt['elife.cfg']('project.is_prod_instance') %}
-    service.running:
-    {% elif pillar.elife.env == 'ci' %}
+    # why is mailserver running in ci ... ?
+    {% if pillar.elife.env in ['prod', 'ci'] %}
     service.running:
     {% else %}
     service.dead:


### PR DESCRIPTION
note: is_prod_instance checked if env was either 'master' or 'prod', but postfix has never been used with the master server
note: 'ci' requires the service to be running and I'm not sure why. are we sending test emails somewhere/how? this might be better handled in pillar data