### PR TITLE
ELPP-3213 Remove systemd apt-daily timers

### DIFF
--- a/elife/daily-system-updates.sls
+++ b/elife/daily-system-updates.sls
@@ -54,3 +54,10 @@ daily-security-updates-cron-disable:
         - name: /etc/cron.daily/apt-compat
 {% endif %}
 
+{% if salt['grains.get']('osrelease') == "16.04" %}
+systemd-unattended-upgrades-disable:
+    cmd.run:
+        - name: |
+            systemctl disable apt-daily.timer
+            systemctl disable apt-daily-upgrade.timer
+{% endif %}


### PR DESCRIPTION
Systemd gently triggers these on boot of new nodes, clashing with the Salt setup.