### PR TITLE
ELPP-3213 Retry Composer update

### DIFF
--- a/elife/composer.sls
+++ b/elife/composer.sls
@@ -78,8 +78,8 @@ composer-global-paths:
             - file: composer-home-dir
 
 update-composer:
-    cmd.run:
-        - name: composer self-update
+    cmd.script:
+        - name: salt://elife/scripts/update-composer.sh
         - onlyif:
             - which composer
         - require_in:

--- a/elife/scripts/update-composer.sh
+++ b/elife/scripts/update-composer.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+log_file="/tmp/update-composer-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
+
+set -o pipefail
+if ! composer self-update 2>&1 | tee "$log_file"; then
+    echo "Composer update failure detected."
+    if grep "Connection timed out" "$log_file"; then
+        echo "Retrying update..."
+        composer self-update
+    else
+        echo "Failure does not seem retriable."
+        exit 2
+    fi
+fi


### PR DESCRIPTION
```
[107.21.139.14] out: [ERROR   ] Command 'composer self-update' failed with return code: 1
[107.21.139.14] out: [ERROR   ] stderr: 
[107.21.139.14] out:   [Composer\Downloader\TransportException]
[107.21.139.14] out:   The "https://getcomposer.org/versions" file could not be downloaded: failed  to open stream: Connection timed out                                        
[107.21.139.14] out: self-update [-r|--rollback] [--clean-backups] [--no-progress] [--update-keys] [--stable] [--preview] [--snapshot] [--set-channel-only] [--] [<version>]
[107.21.139.14] out: [ERROR   ] retcode: 1
```