### PR TITLE
ELPP-3361 Goaws configuration

### DIFF
--- a/elife/config/home-deploy-user-goaws-conf-goaws.yaml
+++ b/elife/config/home-deploy-user-goaws-conf-goaws.yaml
@@ -1,0 +1,8 @@
+Local:
+  Host: goaws
+  Port: 4100
+  Queues:
+    {% for queue_name in pillar.elife.goaws.queues %}
+    - Name: {{ queue_name }}
+    {% endfor %}
+

--- a/elife/config/home-deploy-user-goaws-docker-compose.yml
+++ b/elife/config/home-deploy-user-goaws-docker-compose.yml
@@ -1,8 +1,11 @@
 version: '2'
 services:
-  yopa:
-    container_name: goaws
-    image: elifealfreduser/goaws:20171024
-    ports:
-      - 4100:4100
-    restart: always
+    yopa:
+        container_name: goaws
+        command: -debug
+        image: elifealfreduser/goaws:20171024
+        volumes:
+            - /home/{{ pillar.elife.deploy_user.username }}/goaws/conf:/conf
+        ports:
+            - 4100:4100
+        restart: always

--- a/elife/goaws.sls
+++ b/elife/goaws.sls
@@ -1,9 +1,21 @@
+goaws-configuration:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/goaws/conf/goaws.yaml
+        - source: salt://elife/config/home-deploy-user-goaws-conf-goaws.yaml
+        - template: jinja
+        - user: {{ pillar.elife.deploy_user.username }}
+        - makedirs: True
+        - require:
+            - deploy-user
+
 goaws:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/goaws-docker-compose.yml
         - source: salt://elife/config/home-deploy-user-goaws-docker-compose.yml
+        - template: jinja
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
+            - deploy-user
             - docker-compose
 
     cmd.run:
@@ -11,4 +23,5 @@ goaws:
             /usr/local/bin/docker-compose -f goaws-docker-compose.yml up --force-recreate -d
         - cwd: /home/{{ pillar.elife.deploy_user.username }}
         - require:
+            - goaws-configuration
             - file: goaws

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -201,6 +201,10 @@ elife:
         #secret_access_key: fake
         region: us-east-1
 
+    goaws:
+        queues:
+            - hello-world
+
     forced_dns: {}
 
     coveralls:


### PR DESCRIPTION
- create some queues by default
- specify an host for queues created by default

Not particularly useful in real environments, only for the Vagrant VM of `annotations` and other projects that now mimics `end2end` or `prod` much more than `ci`.