### PR TITLE
Move goaws Docker configuration in its subfolder

### DIFF
--- a/elife/config/home-deploy-user-goaws-.env
+++ b/elife/config/home-deploy-user-goaws-.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=goaws

--- a/elife/goaws.sls
+++ b/elife/goaws.sls
@@ -8,9 +8,17 @@ goaws-configuration:
         - require:
             - deploy-user
 
+goaws-docker-compose-environment:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/goaws/.env
+        - source: salt://elife/config/home-deploy-user-goaws-.env
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - goaws-configuration
+
 goaws:
     file.managed:
-        - name: /home/{{ pillar.elife.deploy_user.username }}/goaws-docker-compose.yml
+        - name: /home/{{ pillar.elife.deploy_user.username }}/goaws/docker-compose.yml
         - source: salt://elife/config/home-deploy-user-goaws-docker-compose.yml
         - template: jinja
         - user: {{ pillar.elife.deploy_user.username }}
@@ -20,8 +28,11 @@ goaws:
 
     cmd.run:
         - name: |
-            /usr/local/bin/docker-compose -f goaws-docker-compose.yml up --force-recreate -d
-        - cwd: /home/{{ pillar.elife.deploy_user.username }}
+            rm -f ../goaws-docker-compose.yml
+            (docker stop goaws && docker rm goaws) || true
+            /usr/local/bin/docker-compose -f docker-compose.yml up --force-recreate -d
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}/goaws
         - require:
             - goaws-configuration
+            - goaws-docker-compose-environment
             - file: goaws


### PR DESCRIPTION
This avoids unwanted interactions of .env files that all reside in /home/elife (e.g. the `annotations` one).