### PR TITLE
Upgrade goaws to 1.0.1

### DIFF
--- a/elife/config/home-deploy-user-goaws-docker-compose.yml
+++ b/elife/config/home-deploy-user-goaws-docker-compose.yml
@@ -3,7 +3,7 @@ services:
     yopa:
         container_name: goaws
         command: -debug
-        image: elifealfreduser/goaws:20171024
+        image: elifesciences/goaws:1.0.1
         volumes:
             - /home/{{ pillar.elife.deploy_user.username }}/goaws/conf:/conf
         ports:


### PR DESCRIPTION
It's on a consolidated Docker Hub account now, that mirrors external dependencies.

Includes bug fixes such as https://github.com/p4tin/goaws/issues/67