### PR TITLE
Reset pm.max_requests

### DIFF
--- a/elife/config/etc-php-7.0-fpm-pool.d-www.conf
+++ b/elife/config/etc-php-7.0-fpm-pool.d-www.conf
@@ -146,7 +146,7 @@ pm.max_spare_servers = {{ max_spare_servers }}
 ; This can be useful to work around memory leaks in 3rd party libraries. For
 ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
 ; Default Value: 0
-pm.max_requests = 1000
+;pm.max_requests = 500
 
 ; The URI to view the FPM status page. If this value is not set, no URI will be
 ; recognized as a status page. It shows the following informations:


### PR DESCRIPTION
Turns out in https://github.com/elifesciences/builder-base-formula/pull/84/files#r150490551 I hadn't spotted that the 500 value is commented out and the default is actually 0. Since it was working fine before we should revert back.