### PR TITLE
Rollback proofreader-php via pinning a commit

### DIFF
--- a/elife/proofreader-php.sls
+++ b/elife/proofreader-php.sls
@@ -1,6 +1,6 @@
 proofreader-php:
     cmd.run:
-        - name: composer global --no-interaction require --update-with-dependencies elife/proofreader-php=dev-master 
+        - name: composer global --no-interaction require --update-with-dependencies elife/proofreader-php='dev-master#83901bb097b39b0df4ddc9d0e841b685977131ab'
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - composer


### PR DESCRIPTION
https://github.com/elifesciences/recommendations/pull/110 evidenced that the current version has broken management of paths and folders