### PR TITLE
Simplify proofreader installation on VMs

### DIFF
--- a/elife/proofreader-php.sls
+++ b/elife/proofreader-php.sls
@@ -1,6 +1,59 @@
-proofreader-php:
-    cmd.run:
-        - name: composer global --no-interaction require --update-with-dependencies elife/proofreader-php='dev-master#83901bb097b39b0df4ddc9d0e841b685977131ab'
-        - user: {{ pillar.elife.deploy_user.username }}
+proofreader-php-repository:
+    builder.git_latest:
+        - name: git@github.com:elifesciences/proofreader-php.git
+        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - rev: master
+        - branch: master
+        - target: /srv/proofreader-php
+        - force_fetch: True
+        - force_checkout: True
+        - force_reset: True
         - require:
             - composer
+
+    file.directory:
+        - name: /srv/proofreader-php
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - recurse:
+            - user
+            - group
+        - require:
+            - builder: proofreader-php-repository
+
+    cmd.run:
+        - name: |
+            composer install
+        - user: {{ pillar.elife.deploy_user.username }}
+        - cwd: /srv/proofreader-php
+        - require:
+            - file: proofreader-php-repository
+
+srv-bin-folder:
+    file.directory:
+        - name: /srv/bin
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - recurse:
+            - user
+            - group
+        - require:
+            - deploy-user
+            - proofreader-php-repository
+
+srv-bin-folder-on-path:
+    file.managed:
+        - name: /etc/profile.d/srv-bin.sh
+        - contents: export PATH=/srv/bin:$PATH
+        - require:
+            - srv-bin-folder
+
+proofreader-php:
+    file.symlink:
+        - name: /srv/bin/proofreader
+        - target: /srv/proofreader-php/bin/proofreader
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - proofreader-php-repository
+            - srv-bin-folder-on-path


### PR DESCRIPTION
Abandon the Composer installation and install into a Git repository like for many other applications. From there it's a simple symlink into a folder on the PATH to use `proofreader`.