### PR TITLE
Make goaws host configurable

### DIFF
--- a/elife/config/home-deploy-user-goaws-conf-goaws.yaml
+++ b/elife/config/home-deploy-user-goaws-conf-goaws.yaml
@@ -1,5 +1,5 @@
 Local:
-  Host: goaws
+  Host: {{ pillar.elife.goaws.host }}
   Port: 4100
   Queues:
     {% for queue_name in pillar.elife.goaws.queues %}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -202,6 +202,9 @@ elife:
         region: us-east-1
 
     goaws:
+        # `localhost` if used from the host
+        # `goaws` if only used from other Docker containers
+        host: localhost
         queues:
             - hello-world
 


### PR DESCRIPTION
It always runs in a container, with the host 4100 port forwarded to it. This caters for both other containers and it being used from an host directly (but not at the same time).