### PR TITLE
ELPP-3361 Add Docker script for reading a label from any image and use it to provision sidecar containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('heavybox', '', 'builder-base-formula')
+elifeFormulaParallel('heavybox', '', 'builder-base-formula')

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -63,12 +63,14 @@ def image_tag():
         return 'latest' # conventionally stable Docker tag
     return revision
 
-def image_label(image, label):
-    """used to retrieve a `label` from an `image`.
+def image_label(image, label, image_tag='latest'):
+    """used to retrieve a `label` from an `image`. 
+    
+    Optionally specify an `image_tag` to pin.
 
     Warning: it will pull the image first, using bandwidth, time and disk space."""
 
-    return subprocess.check_output("/usr/local/docker-scripts/docker-read-label", image, label)
+    return subprocess.check_output("/usr/local/docker-scripts/docker-read-label", "%s:%s" % (image, image_tag), label)
 
 def read_json(path):
     "reads the json from the given `path`, detecting base64 encoded versions."

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -78,6 +78,8 @@ def image_label(image, label, image_tag='latest'):
     value = output.strip()
     if value == 'null':
         raise RuntimeError("`%s` returned a null label" % command)
+    if value == '':
+        raise RuntimeError("`%s` returned a empty string label" % command)
     return value
 
 def read_json(path):

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -1,5 +1,6 @@
 import os, json
 import base64
+import subprocess
 
 import logging
 LOG = logging.getLogger(__name__)
@@ -61,6 +62,13 @@ def image_tag():
     if not revision:
         return 'latest' # conventionally stable Docker tag
     return revision
+
+def image_label(image, label):
+    """used to retrieve a `label` from an `image`.
+
+    Warning: it will pull the image first, using bandwidth, time and disk space."""
+
+    return subprocess.check_output("/usr/local/docker-scripts/docker-read-label", image, label)
 
 def read_json(path):
     "reads the json from the given `path`, detecting base64 encoded versions."

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -70,7 +70,15 @@ def image_label(image, label, image_tag='latest'):
 
     Warning: it will pull the image first, using bandwidth, time and disk space."""
 
-    return subprocess.check_output("/usr/local/docker-scripts/docker-read-label", "%s:%s" % (image, image_tag), label)
+    command = ["/usr/local/docker-scripts/docker-read-label", "%s:%s" % (image, image_tag), label]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = p.communicate()
+    if p.returncode != 0: 
+        raise RuntimeError("Command: %s\nExit status: %s\nSTDOUT: %s\nSTDERR: %s\n" % (command, p.returncode, output, error))
+    value = output.strip()
+    if value == 'null':
+        raise RuntimeError("`%s` returned a null label" % command)
+    return value
 
 def read_json(path):
     "reads the json from the given `path`, detecting base64 encoded versions."

--- a/elife/config/home-deploy-user-configuration-name-.env
+++ b/elife/config/home-deploy-user-configuration-name-.env
@@ -1,0 +1,2 @@
+COMPOSE_PROJECT_NAME={{ name }}
+IMAGE_TAG={{ tag }}

--- a/elife/config/home-deploy-user-configuration-name-.env
+++ b/elife/config/home-deploy-user-configuration-name-.env
@@ -1,2 +1,2 @@
-COMPOSE_PROJECT_NAME={{ name }}
+COMPOSE_PROJECT_NAME={{ name|replace("-", "_") }}
 IMAGE_TAG={{ tag }}

--- a/elife/config/home-deploy-user-configuration-name-docker-compose.yml
+++ b/elife/config/home-deploy-user-configuration-name-docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+    {{ name|replace("-", "_") }}:
+        container_name: {{ name|replace("-", "_") }}
+        image: {{ image }}:${IMAGE_TAG}
+        networks:
+            - sidecars
+        ports:
+            # TODO: make target port customizable
+            - {{ port }}:8080
+        restart: always
+
+networks:
+    sidecars:
+        external: true

--- a/elife/config/home-deploy-user-goaws-docker-compose.yml
+++ b/elife/config/home-deploy-user-goaws-docker-compose.yml
@@ -1,11 +1,17 @@
 version: '2'
 services:
-    yopa:
+    goaws:
         container_name: goaws
         command: -debug
         image: elifesciences/goaws:1.0.1
         volumes:
             - /home/{{ pillar.elife.deploy_user.username }}/goaws/conf:/conf
+        networks:
+            - sidecars
         ports:
             - 4100:4100
         restart: always
+
+networks:
+    sidecars:
+        external: true

--- a/elife/docker-scripts/docker-read-label
+++ b/elife/docker-scripts/docker-read-label
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 IMAGE LABEL"
+    echo "Example: $0 elifesciences/annotations_cli org.elifesciences.dependencies.api-dummy"
+    exit 1
+fi
+
+image="${1}"
+label="${2}"
+docker pull "${image}" 1>&2
+docker inspect "${image}" | jq -r ".[0].Config.Labels.\"${label}\""

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -79,9 +79,25 @@ docker-deploy-user-in-group:
         - require:
             - docker-packages
 
+docker-scripts:
+    file.recurse:
+        - name: /usr/local/docker-scripts/
+        - source: salt://elife/docker-scripts
+        - file_mode: 555
+
+docker-scripts-path:
+    file.managed:
+        - name: /etc/profile.d/docker-scripts-path.sh
+        - contents: export PATH=/usr/local/docker-scripts:$PATH
+        - mode: 644
+        - require: 
+            - docker-scripts
+
 docker-ready:
     cmd.run:
         - name: docker version
         - require:
             - docker-compose
             - docker-deploy-user-in-group
+            - docker-scripts
+            - docker-scripts-path

--- a/elife/goaws.sls
+++ b/elife/goaws.sls
@@ -1,3 +1,12 @@
+# remove once dependency on docker-network-sidecars in elife.sidecars is correctly in place in all projects
+docker-network-sidecars-goaws-deprecated:
+    cmd.run:
+        - name: docker network create sidecars
+        - unless:
+            - docker network inspect sidecars
+        - require:
+            - docker-ready
+
 goaws-configuration:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/goaws/conf/goaws.yaml
@@ -7,6 +16,7 @@ goaws-configuration:
         - makedirs: True
         - require:
             - deploy-user
+            - docker-network-sidecars-goaws-deprecated
 
 goaws-docker-compose-environment:
     file.managed:

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -7,7 +7,7 @@ docker-network-sidecars:
             - docker-ready
 
 {% for key, configuration in pillar.elife.sidecars.containers.items() %}
-# TODO: use configuration['enabled'] to turn on/off
+{% if configuration['enabled'] %}
 
 docker-compose-{{ configuration['name'] }}:
     file.managed:
@@ -42,4 +42,6 @@ docker-compose-{{ configuration['name'] }}-up:
         - require: 
             - docker-compose-{{ configuration['name'] }}
             - docker-compose-{{ configuration['name'] }}-.env
+
+{% endif %}
 {% endfor %}

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -1,0 +1,44 @@
+docker-network-sidecars:
+    cmd.run:
+        - name: docker network create sidecars
+        - unless:
+            - docker network inspect sidecars
+        - require:
+            - docker-ready
+
+{% for key, configuration in pillar.elife.sidecars.containers.items() %}
+# TODO: use configuration['enabled'] to turn on/off
+
+docker-compose-{{ configuration['name'] }}:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/{{ configuration['name'] }}/docker-compose.yml
+        - source: salt://elife/config/home-deploy-user-configuration-name-docker-compose.yml
+        - template: jinja
+        - context:
+            image: {{ configuration['image'] }}
+            name: {{ configuration['name'] }}
+            port: {{ configuration['port'] }}
+        - makedirs: True
+        - require: 
+            - deploy-user
+            - docker-ready
+
+docker-compose-{{ configuration['name'] }}-.env:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/{{ configuration['name'] }}/.env
+        - source: salt://elife/config/home-deploy-user-configuration-name-.env
+        - template: jinja
+        - context:
+            tag: {{ salt['elife.image_label'](pillar.elife.sidecars.main, 'org.elifesciences.dependencies.'+configuration['name']), salt['elife.image_tag']() }}
+        - makedirs: True
+        - require: 
+            - docker-compose-{{ configuration['name'] }}
+
+docker-compose-{{ configuration['name'] }}-up:
+    cmd.run:
+        - name: /usr/local/bin/docker-compose -f docker-compose.yml up --force-recreate -d
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}/{{ configuration['name'] }}
+        - require: 
+            - docker-compose-{{ configuration['name'] }}
+            - docker-compose-{{ configuration['name'] }}-.env
+{% endfor %}

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -29,7 +29,7 @@ docker-compose-{{ configuration['name'] }}-.env:
         - source: salt://elife/config/home-deploy-user-configuration-name-.env
         - template: jinja
         - context:
-            tag: {{ salt['elife.image_label'](pillar.elife.sidecars.main, 'org.elifesciences.dependencies.'+configuration['name']), salt['elife.image_tag']() }}
+            tag: {{ salt['elife.image_label'](pillar.elife.sidecars.main, 'org.elifesciences.dependencies.'+configuration['name'], salt['elife.image_tag']()) }}
         - makedirs: True
         - require: 
             - docker-compose-{{ configuration['name'] }}

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -15,8 +15,8 @@ docker-compose-{{ configuration['name'] }}:
         - source: salt://elife/config/home-deploy-user-configuration-name-docker-compose.yml
         - template: jinja
         - context:
-            image: {{ configuration['image'] }}
             name: {{ configuration['name'] }}
+            image: {{ configuration['image'] }}
             port: {{ configuration['port'] }}
         - makedirs: True
         - require: 
@@ -29,6 +29,7 @@ docker-compose-{{ configuration['name'] }}-.env:
         - source: salt://elife/config/home-deploy-user-configuration-name-.env
         - template: jinja
         - context:
+            name: {{ configuration['name'] }}
             tag: {{ salt['elife.image_label'](pillar.elife.sidecars.main, 'org.elifesciences.dependencies.'+configuration['name'], salt['elife.image_tag']()) }}
         - makedirs: True
         - require: 

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -208,6 +208,9 @@ elife:
         queues:
             - hello-world
 
+    sidecars:
+        containers: {}
+
     forced_dns: {}
 
     coveralls:

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -209,7 +209,15 @@ elife:
             - hello-world
 
     sidecars:
+        # main image that will be used to extract labels 
+        # indicating metadata about the sidecars such as their own tags
+        # main: elifesciences/annotations_cli
         containers: {}
+            #api_dummy:
+            #    image: elifesciences/api-dummy
+            #    name: api-dummy
+            #    port: 8001
+            #    enabled: True
 
     forced_dns: {}
 

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -184,7 +184,7 @@ elife:
                 #    number: 1
                 #    [require: some-state]
 
-    php_dummies:
+    php_dummies: {}
         #orcid_dummy:
         #    repository: https://github.com/elifesciences/orcid-dummy
         #    pinned_revision_file: /srv/profiles/orcid-dummy.sha1


### PR DESCRIPTION
Sidecar containers are used across applications to provide an instance of a common service.
<img src="https://vignette1.wikia.nocookie.net/indianajones/images/e/ed/R75_escape.jpg/revision/latest?cb=20170818165706" width=400 />
We have several dummy implementation of services that can be used in this way, such as `api-dummy`.

Let's say I want to deploy `annotations` somewhere and I need to know which version of `api-dummy` it should be using:
```
$ elife/docker-scripts/docker-read-label elifesciences/annotations_cli 'org.elifesciences.dependencies.api-dummy' 2>/dev/null
05ab239fa0eec32b3f36ca2dc8117123e2879717
```

Once I know the version, I can run that and other sidecar images with its own `docker-compose` configuration:
```
version: '2'                                                                                                                                      
services:
    api_dummy:
        container_name: api_dummy
        image: elifesciences/api-dummy:${IMAGE_TAG}
        networks:
            - sidecars
        ports:
            # TODO: make target port customizable
            - 8001:8080
        restart: always

networks:
    sidecars:
        external: true
```

The new container joins a `sidecars` network that, when joined by an application too, makes it visible at `api-dummy:8080`. For ease of debugging, we make the sidecar also accessible on the host at `localhost:8001` if someone want to run a `curl` against it (the application doesn't rely on it instead).
