### PR TITLE
Update ElastiCache outputs

### DIFF
--- a/elife/redis-server.sls
+++ b/elife/redis-server.sls
@@ -22,6 +22,10 @@ redis-packages-install:
 
 {% else %}
 redis-packages-install:
+    pkg.purged:
+        - pkgs:
+            - redis-server
+
     pkg.installed:
         - pkgs:
             - redis-tools # includes redis-cli

--- a/elife/redis-server.sls
+++ b/elife/redis-server.sls
@@ -1,4 +1,4 @@
-{% set on_elasticache = salt['elife.cfg']('cfn.outputs.ElastiCacheHost') %}
+{% set on_elasticache = salt['elife.cfg']('cfn.outputs.ElastiCacheHost1') %}
 
 {% set distro = salt['grains.get']('oscodename') %}
 


### PR DESCRIPTION
The CloudFormation output names have been changed since the introduction of multiple ElastiCache resources. This resulted in `journal--prod` servers still running a local Redis daemon, which is not being used.