### PR TITLE
ELPP-3361 Move custom module call in template file

### DIFF
--- a/elife/config/home-deploy-user-configuration-name-.env
+++ b/elife/config/home-deploy-user-configuration-name-.env
@@ -1,2 +1,2 @@
-COMPOSE_PROJECT_NAME={{ name|replace("-", "_") }}
-IMAGE_TAG={{ tag }}
+COMPOSE_PROJECT_NAME={{ configuration["name"]|replace("-", "_") }}
+IMAGE_TAG={{ salt["elife.image_label"](pillar.elife.sidecars.main, "org.elifesciences.dependencies."+configuration["name"], salt["elife.image_tag"]()) }}

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -29,8 +29,8 @@ docker-compose-{{ configuration['name'] }}-.env:
         - source: salt://elife/config/home-deploy-user-configuration-name-.env
         - template: jinja
         - context:
-            name: {{ configuration['name'] }}
-            tag: {{ salt['elife.image_label'](pillar.elife.sidecars.main, 'org.elifesciences.dependencies.'+configuration['name'], salt['elife.image_tag']()) }}
+            main: {{ pillar.elife.sidecars.main }}
+            configuration: {{ configuration }}
         - makedirs: True
         - require: 
             - docker-compose-{{ configuration['name'] }}


### PR DESCRIPTION
`elife.image_label` requires docker and some of our scripts to be installed to work. Therefore, it cannot be called inside a  file as that is rendered at the start of the highstate.

Instead, calling the module inside a template for `file.managed` allows all the previous states to run before Docker is used.

Avoids the messy https://github.com/elifesciences/builder-private/pull/125