### PR TITLE
Sidecars configuration tuning

### DIFF
--- a/elife/config/home-deploy-user-configuration-name-.env
+++ b/elife/config/home-deploy-user-configuration-name-.env
@@ -1,2 +1,6 @@
 COMPOSE_PROJECT_NAME={{ configuration["name"]|replace("-", "_") }}
+{% if configuration.get('tag') %}
+IMAGE_TAG={{ configuration.get('tag') }}
+{% else %}
 IMAGE_TAG={{ salt["elife.image_label"](pillar.elife.sidecars.main, "org.elifesciences.dependencies."+configuration["name"], salt["elife.image_tag"]()) }}
+{% endif %}

--- a/elife/config/home-deploy-user-configuration-name-docker-compose.yml
+++ b/elife/config/home-deploy-user-configuration-name-docker-compose.yml
@@ -5,9 +5,10 @@ services:
         image: {{ image }}:${IMAGE_TAG}
         networks:
             - sidecars
+        {% if port %}
         ports:
-            # TODO: make target port customizable
             - {{ port }}:8080
+        {% endif %}
         restart: always
 
 networks:

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -17,7 +17,7 @@ docker-compose-{{ configuration['name'] }}:
         - context:
             name: {{ configuration['name'] }}
             image: {{ configuration['image'] }}
-            port: {{ configuration['port'] }}
+            port: {{ configuration.get('port') }}
         - makedirs: True
         - require: 
             - deploy-user


### PR DESCRIPTION
- Allow sidecar image tag in pillar rather than on main image label
- Allow to specify no port to forward from host