### PR TITLE
Extract elife.postgres_client

### DIFF
--- a/elife/postgresql-client.sls
+++ b/elife/postgresql-client.sls
@@ -1,0 +1,17 @@
+# http://www.postgresql.org/download/linux/ubuntu/
+postgresql-deb:
+    cmd.run:
+        - name: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+    pkgrepo.managed:
+        # http://www.postgresql.org/download/linux/ubuntu/
+        - humanname: Official Postgresql Ubuntu LTS
+        - name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
+        - require:
+            - cmd: postgresql-deb
+
+postgresql:
+    pkg.installed:
+        - pkgs:
+            - postgresql-client-9.4
+        - refresh: True

--- a/elife/postgresql-client.sls
+++ b/elife/postgresql-client.sls
@@ -10,7 +10,7 @@ postgresql-deb:
         - require:
             - cmd: postgresql-deb
 
-postgresql:
+postgresql-client:
     pkg.installed:
         - pkgs:
             - postgresql-client-9.4

--- a/elife/postgresql.sls
+++ b/elife/postgresql.sls
@@ -1,14 +1,5 @@
-# http://www.postgresql.org/download/linux/ubuntu/
-postgresql-deb:
-    cmd.run:
-        - name: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
-    pkgrepo.managed:
-        # http://www.postgresql.org/download/linux/ubuntu/
-        - humanname: Official Postgresql Ubuntu LTS
-        - name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
-        - require:
-            - cmd: postgresql-deb
+include:
+    - .postgresql-client 
 
 pgpass-file:
     file.managed:


### PR DESCRIPTION
When you use a container for postgres, you'll still need a client to access it. You could use the container also as a client, but that's a change for later.