### PR TITLE
ELPP-3432 Support PyPI credentials

### DIFF
--- a/elife/config/home-deploy-user-.pypirc
+++ b/elife/config/home-deploy-user-.pypirc
@@ -1,0 +1,5 @@
+[pypirc]
+servers = pypi
+[server-login]
+username: {{ pillar.pypi.username }}
+password: {{ pillar.pypi.password }}

--- a/elife/pypi.sls
+++ b/elife/pypi.sls
@@ -1,0 +1,7 @@
+pypi-credentials:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/.pypirc
+        - source: salt://elife/config/home-deploy-user-.pypirc
+        - template: jinja
+        - require:
+            - deploy-user

--- a/pillar/pypi.sls
+++ b/pillar/pypi.sls
@@ -1,0 +1,3 @@
+pypi:
+    username: fakeusername
+    password: fakepassword


### PR DESCRIPTION
Trying a different approach to the usual: to achieve better segregation, putting the credentials into a separate `pypi` pillar. This should only be included on the instances that actually need it rather than everywhere like for the blanket `pillar.elife.*`.