### PR TITLE
Automated resize of filesystem on external volume

### DIFF
--- a/elife/external-volume-srv.sls
+++ b/elife/external-volume-srv.sls
@@ -7,6 +7,7 @@ srv-directory:
         - name: /ext/srv
         - require:
             - mount-external-volume
+            - resize-external-volume-if-needed
         #- require_in:
         #    - file: new-ubr-config
 

--- a/elife/external-volume.sls
+++ b/elife/external-volume.sls
@@ -36,6 +36,19 @@ mount-external-volume:
             # mount point already has a volume mounted
             - cat /proc/mounts | grep --quiet --no-messages {{ pillar.elife.external_volume.directory }}
 
+# in case the volume has been expanded
+# only supports volumes with no partitions,
+# which is what builder creates
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html
+resize-external-volume-if-needed:
+    cmd.run:
+        - name: resize2fs {{ pillar.elife.external_volume.device }}
+        - onlyif:
+            # disk exists
+            - test -b {{ pillar.elife.external_volume.device }}
+        - require:
+            - mount-external-volume
+
 tmp-directory-on-external-volume:
     file.directory:
         - name: /ext/tmp


### PR DESCRIPTION
If we expand a volume through CloudFormation (or the EBS API in
general), the filesystem on it needs to be expanded to take advantage of
the newly available space.

This ensures a Salt highstate will make `df -h` see all the space that
is not available through `lsblk`.