### PR TITLE
known-hosts, fixes bug in Salt upgrade where default hash_type changed

### DIFF
--- a/elife/known-hosts.sls
+++ b/elife/known-hosts.sls
@@ -6,7 +6,9 @@ github.com:
     ssh_known_hosts.present:
         - fingerprint: 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
         - enc: ssh-rsa
+        - fingerprint_hash_type: md5
         - unless:
+            # BUG: doesn't seem to be working, entries are accumulating
             - grep -r "^github.com," /etc/ssh/ssh_known_hosts
 
 


### PR DESCRIPTION
see:
* https://docs.saltstack.com/en/2017.7/ref/states/all/salt.states.ssh_known_hosts.html#salt.states.ssh_known_hosts.present
* https://docs.saltstack.com/en/2017.7/ref/modules/all/salt.modules.ssh.html#salt.modules.ssh.recv_known_host

you can do this to play around with the parameters `sudo salt-call ssh.recv_known_host bitbucket.org enc=ssh-rsa`