### PR TITLE
ELPP-3693 Allow to run builds as the ubuntu user

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -71,11 +71,12 @@ docker-compose:
         - require:
             - file: docker-compose
 
-docker-deploy-user-in-group:
+docker-users-in-group:
     group.present:
         - name: docker
         - addusers:
             - {{ pillar.elife.deploy_user.username }}
+            - ubuntu
         - require:
             - docker-packages
 
@@ -98,6 +99,6 @@ docker-ready:
         - name: docker version
         - require:
             - docker-compose
-            - docker-deploy-user-in-group
+            - docker-users-in-group
             - docker-scripts
             - docker-scripts-path

--- a/elife/jenkins-node.sls
+++ b/elife/jenkins-node.sls
@@ -11,14 +11,16 @@ libraries-runner-directory:
 # to get all environment variables like PATH
 # when executing commands over SSH (which is what Jenkins does
 # to start the slave)
-jenkins-bashrc-sourcing-profile:
+{% for user in [pillar.elife.deploy_user.username, 'ubuntu'] %}
+jenkins-bashrc-sourcing-profile-user-{{ user }}:
     file.prepend:
-        - name: /home/{{ pillar.elife.deploy_user.username }}/.bashrc
+        - name: /home/{{ user }}/.bashrc
         - text:
             - "# to load PATH and env variables in all ssh commands"
             - source /etc/profile
         - require:
             - deploy-user
+{% endfor %}
 
 jenkins-slave-node-folder:
     file.symlink:


### PR DESCRIPTION
This node is used by Jenkins to run builds or part of builds. It usually uses SSH access through the `elife` user, but for simplicity the EC2 plugin should use the `ubuntu` user instead.  

The plugin creates throwaway instances from an AMI, hence its own configured keypair is only added to the `ubuntu` user and `elife` is locked out (all access is removed in the AMI creation process). Human users can still log in through the `elife-alfred--prod` instance, which has the keypair.