### PR TITLE
ELPP-3693 Provision AWS credentials to ubuntu user too

### DIFF
--- a/elife/aws-credentials.sls
+++ b/elife/aws-credentials.sls
@@ -26,3 +26,12 @@ aws-credentials-www-data-user:
             # if user home folder exists
             - test -d /var/www
         # no clear require, since webserver user could be created by uwsgi, php-fpm, nginx...
+
+aws-credentials-ubuntu-user:
+    file.managed:
+        - name: /home/ubuntu/.aws/credentials
+        - source: salt://elife/config/home-deploy-user-.aws-credentials
+        - user: ubuntu
+        - group: ubuntu
+        - makedirs: True
+        - template: jinja


### PR DESCRIPTION
User has the same sudo powers as the `elife` one. Used by Jenkins when creating `containers` nodes dynamically and running builds on them.