### PR TITLE
Avoid cron emails

### DIFF
--- a/elife/cron.sls
+++ b/elife/cron.sls
@@ -1,0 +1,13 @@
+cron-root-user-emails:
+    cron.env_present:
+        - name: MAILTO
+        - user: root
+        - value: ""
+
+deploy-user-user-emails:
+    cron.env_present:
+        - name: MAILTO
+        - user: {{ pillar.elife.deploy_user.username }}
+        - value: ""
+        - require:
+            - deploy-user

--- a/elife/init.sls
+++ b/elife/init.sls
@@ -8,6 +8,7 @@ include:
     - .dhcp
     - .known-hosts
     - .deploy-user
+    - .cron
     - .time-correction
     - .backups
     - .coveralls


### PR DESCRIPTION
By default cron sends emails (with the output of commands that are run)
to local users, who will never read the content e.g.
`elife@prod--journal-cms.elifesciences.org`.

By setting the environment in this way, emails should not be created.