### PR TITLE
installation of python/pip/setuptools is now handled in bootstrap script

### DIFF
--- a/elife/aws-cli.sls
+++ b/elife/aws-cli.sls
@@ -1,6 +1,4 @@
 aws-cli:
     pip.installed:
         - name: awscli
-        - require:
-            - python-2.7
 

--- a/elife/python.sls
+++ b/elife/python.sls
@@ -75,6 +75,10 @@ python-dev:
             - libffi-dev 
             - libssl-dev
 
+python-pip:
+    cmd.run:
+        - name: echo Managed by builder. Remove when no other formulas depend on it
+
 global-python-requisites:
     cmd.run:
         # rmrf_enter is DEPRECATED

--- a/elife/python.sls
+++ b/elife/python.sls
@@ -66,14 +66,7 @@ global-python-requisites:
 
 # DEPRECATED. removed after switch to 16.04
 
-python-2.7:
-    pkg.installed:
-        - name: python2.7
-        # these don't work to upgrade if 'python2.7' already installed
-        # and it's in the base box so this should never do anything
-        #- refresh: True
-        #- allow_updates: True
-        #- reload_modules: True
+# WARN: assumes python 2.7.12+ are already installed via bootstrap script
 
 python-dev:
     pkg.installed:
@@ -82,63 +75,12 @@ python-dev:
             - libffi-dev 
             - libssl-dev
 
-# https://github.com/saltstack/salt/issues/28036
-#python-pip:
-#    pkg.installed
-
-python-pip:
-    pkg.removed:
-        - pkgs:
-            - python-pip
-            - python-pip-whl
-        - require_in:
-            - pkg: pip-shim
-
-pip-shim:
-    pkg.installed:
-        - pkgs:
-            - python-setuptools
-
-    cmd.run:
-        # issue with newer versions of pip
-        # https://github.com/saltstack/salt/issues/33163
-        - name: easy_install "pip<=8.1.1"
-        - require:
-            - pkg: pip-shim
-    # https://github.com/saltstack/salt/issues/28036
-    # sacrificial state that does nothing except reload modules + fail silently
-    pip.installed:
-        - name: "pip<=8.1.1"
-        - reload_modules: True
-        - check_cmd:
-            # fail silently
-            - /bin/true
-        - require:
-            - cmd: pip-shim
-
-
 global-python-requisites:
-    pip.installed:
-        - pkgs:
-            - virtualenv>=13
-            # rmrf_enter is DEPRECATED
-            # elife's delete script for stuff that accumulates
-            - "git+https://github.com/elifesciences/rmrf_enter.git@master#egg=rmrf_enter" 
+    cmd.run:
+        # rmrf_enter is DEPRECATED
+        # elife's delete script for stuff that accumulates
+        - name: /usr/bin/python2.7 -m pip install virtualenv>=13 "git+https://github.com/elifesciences/rmrf_enter.git@master#egg=rmrf_enter" --no-cache-dir
         - require:
             - pkg: base
-            - pkg: python-pip
-
-# pkgrepo for 2.7.12, should already be configured by builder's Salt bootstrap
-# officially abandoned
-python-2.7+:
-    pkgrepo.managed:
-        - humanname: Python 2.7 Updates
-        - ppa: fkrull/deadsnakes-python2.7
-        - require:
-            - python-2.7
-            - python-dev
-            - global-python-requisites
-        - unless:
-            - test -e /etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list
 
 {% endif %}

--- a/elife/python.sls
+++ b/elife/python.sls
@@ -66,7 +66,8 @@ global-python-requisites:
 
 # DEPRECATED. removed after switch to 16.04
 
-# WARN: assumes python 2.7.12+ are already installed via bootstrap script
+# WARN: assumes python 2.7.12+, pip and setuptools are already installed and 
+# updated via bootstrap script
 
 python-dev:
     pkg.installed:
@@ -74,6 +75,10 @@ python-dev:
             - python-dev
             - libffi-dev 
             - libssl-dev
+
+python-2.7:
+    cmd.run:
+        - name: echo Managed by builder. Remove when no other formulas depend on it
 
 python-pip:
     cmd.run:

--- a/elife/uwsgi.sls
+++ b/elife/uwsgi.sls
@@ -21,8 +21,7 @@ uwsgi-pkg:
     pip.installed:
         - name: uwsgi >= 2.0.8
         - require:
-            - pkg: python-pip
-            - pkg: python-dev
+            - python-dev
         - reload_modules: True
 {% endif %}
 


### PR DESCRIPTION
removes a lot of cruft for an ancient 'fix'

(depends on https://github.com/elifesciences/builder/pull/365)