### PR TITLE
Kubectl, gcloud and other tooling for deploying to GKE

### DIFF
--- a/elife/gcloud.sls
+++ b/elife/gcloud.sls
@@ -1,0 +1,20 @@
+google-cloud-packages-repo:
+    cmd.run:
+        - name: curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        - unless:
+            - apt-key list | grep BA07F4FB
+
+    pkgrepo.managed:
+        - humanname: Kubernetes tooling
+        - name: deb http://apt.kubernetes.io/ cloud-sdk-xenial main
+        - file: /etc/apt/sources.list.d/google-cloud.list
+        - require:
+            - cmd: google-cloud-packages-repo
+        - unless:
+            - test -e /etc/apt/sources.list.d/google-cloud.list
+
+gcloud-package:
+    pkg.installed:
+        - name: google-cloud-sdk
+        - require:
+            - google-cloud-packages-repo

--- a/elife/kubectl.sls
+++ b/elife/kubectl.sls
@@ -1,0 +1,32 @@
+kubernetes-pkgrepo:
+    cmd.run:
+        - name: curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        - unless:
+            - apt-key list | grep BA07F4FB
+
+    pkgrepo.managed:
+        - humanname: Kubernetes tooling
+        - name: deb http://apt.kubernetes.io/ kubernetes-xenial main
+        - file: /etc/apt/sources.list.d/kubernetes.list
+        - require:
+            - cmd: kubernetes-pkgrepo
+        - unless:
+            - test -e /etc/apt/sources.list.d/kubernetes.list
+
+kubectl-package:
+    pkg.installed:
+        - name: kubectl
+        - require:
+            - kubernetes-pkgrepo
+
+{% for filename, source in pillar.elife.kubectl.kubeconfigs.items() %}
+kubectl-kubeconfig-{{ filename }}:
+    file.managed:
+        - name: {{ pillar.elife.kubectl.directory }}/{{ filename }}
+        - source: {{ source }}
+        - user: {{ pillar.elife.kubectl.username }}
+        - group: {{ pillar.elife.kubectl.username }}
+        - makedirs: True
+        - require:
+            - kubectl-package
+{% endfor %}

--- a/elife/kubectl.sls
+++ b/elife/kubectl.sls
@@ -1,4 +1,4 @@
-kubernetes-pkgrepo:
+kubernetes-packages-repo:
     cmd.run:
         - name: curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
         - unless:
@@ -9,7 +9,7 @@ kubernetes-pkgrepo:
         - name: deb http://apt.kubernetes.io/ kubernetes-xenial main
         - file: /etc/apt/sources.list.d/kubernetes.list
         - require:
-            - cmd: kubernetes-pkgrepo
+            - cmd: kubernetes-packages-repo
         - unless:
             - test -e /etc/apt/sources.list.d/kubernetes.list
 
@@ -17,16 +17,4 @@ kubectl-package:
     pkg.installed:
         - name: kubectl
         - require:
-            - kubernetes-pkgrepo
-
-{% for filename, source in pillar.elife.kubectl.kubeconfigs.items() %}
-kubectl-kubeconfig-{{ filename }}:
-    file.managed:
-        - name: {{ pillar.elife.kubectl.directory }}/{{ filename }}
-        - source: {{ source }}
-        - user: {{ pillar.elife.kubectl.username }}
-        - group: {{ pillar.elife.kubectl.username }}
-        - makedirs: True
-        - require:
-            - kubectl-package
-{% endfor %}
+            - kubernetes-packages-repo

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -167,7 +167,7 @@ elife:
         password: null
 
     gcloud:
-        directory: /home/elife/
+        directory: /home/elife
         username: elife
         accounts: {} # name to path to JSON credentials
         # accounts: 

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -166,6 +166,11 @@ elife:
         username: elifealfreduser
         password: null
 
+    kubectl:
+        directory: /home/elife/.kube/
+        username: elife
+        kubeconfigs: {}
+
     external_volume:
         device: /dev/xvdh
         filesystem: ext4

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -169,7 +169,9 @@ elife:
     kubectl:
         directory: /home/elife/.kube/
         username: elife
-        kubeconfigs: {}
+
+    gcloud:
+        accounts: {} # name to path to JSON credentials
 
     external_volume:
         device: /dev/xvdh

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -166,12 +166,15 @@ elife:
         username: elifealfreduser
         password: null
 
-    kubectl:
-        directory: /home/elife/.kube/
-        username: elife
-
     gcloud:
+        directory: /home/elife/
+        username: elife
         accounts: {} # name to path to JSON credentials
+        # accounts: 
+        #     data-pipeline:
+        #         credentials: "salt://elife/config/.../service-account.json"
+        #         cluster: data-pipeline
+        #         zone: us-east4-a
 
     external_volume:
         device: /dev/xvdh


### PR DESCRIPTION
The tool of choice for interacting with Kubernetes clusters. This should be managed by builder in the long term, but unless it provides within a container, the binary still has to be present.

The configuration contains sensitive credentials to access the cluster.