### PR TITLE
16.04 machines use openjdk-8 and remove oracle java

### DIFF
--- a/elife/java.sls
+++ b/elife/java.sls
@@ -1,5 +1,6 @@
 {% if salt['grains.get']('osrelease') == "16.04" %}
 
+# note: we might want to treat this java.sls as 'java7.sls' and remove this state
 openjdk-jre:
     pkg.installed:
         - pkgs:


### PR DESCRIPTION
still a bit of a work-in-progress, but one way to avoid oracle 8 is to upgrade to 16.04