### PR TITLE
Script waiting for Docker daemon to start

### DIFF
--- a/elife/docker-scripts/docker-wait-daemon
+++ b/elife/docker-scripts/docker-wait-daemon
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+timeout="${1:-120}"
+socket="/var/run/docker.sock"
+
+echo "Waiting for socket $socket to be writable"
+# similar to elife/utils/wait_for_port but with Unix sockets (-U)
+timeout "$timeout" sh -c "while ! nc -q0 -w1 -U $socket </dev/null >/dev/null 2>&1; do sleep 1; done"
+echo "Connection was established on $socket"

--- a/elife/docker-scripts/docker-wait-daemon
+++ b/elife/docker-scripts/docker-wait-daemon
@@ -5,6 +5,11 @@ timeout="${1:-120}"
 socket="/var/run/docker.sock"
 
 echo "Waiting for socket $socket to be writable"
-# similar to elife/utils/wait_for_port but with Unix sockets (-U)
+# similar to elife/utils/wait_for_port,
+# poll until a connection to the docker daemon can be established
+# - connect and time out after 1 seconds (-w)
+# - wait for 0 seconds (-q)
+# - use Unix sockets rather than hosts and ports (-U)
+# - silence stdout and stderr
 timeout "$timeout" sh -c "while ! nc -q0 -w1 -U $socket </dev/null >/dev/null 2>&1; do sleep 1; done"
 echo "Connection was established on $socket"


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4377

We have had builds like https://alfred.elifesciences.org/job/test/job/test-digests/22/console:
```
[1748] Failed to execute script docker-compose
...
requests.exceptions.ReadTimeout: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
```

The Docker daemon taking >1 minute to start seems to be the culprit, the underlying cause probably being the fact that this may be a brand new EC2 instance or having just been rebooted, hence needing to populate caches and do general bootstrap work.

This script should help to wait for the daemon to be available before starting builds that will fail in this way.