### PR TITLE
Remove bucket_cdn from spectrum configuration

### DIFF
--- a/elife/config/srv-elife-spectrum-app.cfg
+++ b/elife/config/srv-elife-spectrum-app.cfg
@@ -7,7 +7,6 @@ aws_secret_access_key: {{ pillar.elife.spectrum.end2end.aws.secret_access_key }}
 bucket_input: {{ pillar.elife.spectrum.end2end.bot.bucket.input }} 
 bucket_digests_input: {{ pillar.elife.spectrum.end2end.bot.bucket.digests_input }} 
 bucket_eif: {{ pillar.elife.spectrum.end2end.bot.bucket.eif }}
-bucket_cdn: {{ pillar.elife.spectrum.end2end.bot.bucket.cdn }}
 bucket_archive: {{ pillar.elife.spectrum.end2end.bot.bucket.archive }}
 bucket_published: {{ pillar.elife.spectrum.end2end.bot.bucket.published }}
 bucket_silent_corrections: {{ pillar.elife.spectrum.end2end.bot.bucket.silent_corrections }}
@@ -44,7 +43,6 @@ aws_secret_access_key: {{ pillar.elife.spectrum.continuumtest.aws.secret_access_
 bucket_input: {{ pillar.elife.spectrum.continuumtest.bot.bucket.input }} 
 bucket_digests_input: {{ pillar.elife.spectrum.continuumtest.bot.bucket.digests_input }} 
 bucket_eif: {{ pillar.elife.spectrum.continuumtest.bot.bucket.eif }}
-bucket_cdn: {{ pillar.elife.spectrum.continuumtest.bot.bucket.cdn }}
 bucket_archive: {{ pillar.elife.spectrum.continuumtest.bot.bucket.archive }}
 bucket_published: {{ pillar.elife.spectrum.continuumtest.bot.bucket.published }}
 bucket_silent_corrections: {{ pillar.elife.spectrum.continuumtest.bot.bucket.silent_corrections }}
@@ -81,7 +79,6 @@ aws_secret_access_key:
 bucket_input: 
 bucket_digests_input:
 bucket_eif: 
-bucket_cdn: 
 bucket_archive: 
 bucket_published: 
 bucket_silent_corrections: 

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -261,7 +261,6 @@ elife:
                     input: null
                     digests_input: null
                     eif: null
-                    cdn: null
                     archive: null
                     published: null
                     silent_corrections: null
@@ -307,7 +306,6 @@ elife:
                     input: null
                     digests_input: null
                     eif: null
-                    cdn: null
                     archive: null
                     published: null
                     silent_corrections: null


### PR DESCRIPTION
From https://github.com/elifesciences/issues/issues/4369 as it's now covered by `bucket_published`.