### PR TITLE
Mysql 5.7 update

### DIFF
--- a/elife/mysql57.sls
+++ b/elife/mysql57.sls
@@ -68,7 +68,8 @@ mysql-server:
             #- mysql-server: 5.7.19-1ubuntu14.04
             #- mysql-server: 5.7.20-1ubuntu14.04
             #- mysql-server: 5.7.21-1ubuntu14.04
-            - mysql-server: 5.7.22-1ubuntu14.04
+            #- mysql-server: 5.7.22-1ubuntu14.04
+            - mysql-server: 5.7.23-1ubuntu14.04
 
         # not necessary, done in mysql-clients
         # - refresh: True


### PR DESCRIPTION
Old version has been removed from repositories, hence we need to update to fix automated builds and highstates on new instances