### PR TITLE
Feature: add python3.6-venv to list of packages installed during bootstrap

### DIFF
--- a/elife/python3.sls
+++ b/elife/python3.sls
@@ -35,6 +35,7 @@ python-3:
             - python3.5-dev
             - python3.6
             - python3.6-dev
+            - python3.6-venv
 
             # ubuntu ... ffs. issue exists in 16.04 too
             # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847


### PR DESCRIPTION
installs python3.6-venv so we can create virtual environments with `python3 -m venv` in 14.04 and 18.04