### PR TITLE
Revert "Revert "Feature: add python3.6-venv to list of packages installed during bootstrap""

### DIFF
--- a/elife/python3.sls
+++ b/elife/python3.sls
@@ -35,6 +35,7 @@ python-3:
             - python3.5-dev
             - python3.6
             - python3.6-dev
+            - python3.6-venv
 
             # ubuntu ... ffs. issue exists in 16.04 too
             # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847


### PR DESCRIPTION
Reverts elifesciences/builder-base-formula#176

FML it *is* required as it's failing without it in end2end. I hate ubuntu *so much* sometimes.