### PR TITLE
Only print pinned commit in update dependency pipeline

### DIFF
--- a/elife/utils/update_python_dependency
+++ b/elife/utils/update_python_dependency
@@ -19,4 +19,4 @@ cd - 1>&2
 sed -i -e "s;.*${remote}.*;git+${remote}@${dependency_sha1}#egg=${name};g" requirements.txt
 pip uninstall -y "$name" 1>&2
 pip install -r requirements.txt 1>&2
-echo "pinned $name in requirements.txt to $dependency_sha1"
+echo "$dependency_sha1"


### PR DESCRIPTION
Titles like:

```
Updated digestparser: pinned digestparser in requirements.txt to 88c712a4d4d9c4a45fefbb820859151de49d8cc9
```


can be reduced to:

```
Updated digestparser: 88c712a4d4d9c4a45fefbb820859151de49d8cc9
```

Sample from https://github.com/elifesciences/elife-bot/pull/779