### PR TITLE
Simplify 3rd party repositories banning

### DIFF
--- a/elife/python.sls
+++ b/elife/python.sls
@@ -7,32 +7,11 @@
 # TODO: remove when all projects are using 16.04+
 #
 
-dead-snakes-are-dead:
-    pkgrepo.absent:
-        - ppa: fkrull/deadsnakes-python2.7
-
-jonothonf-is-missing:
-    pkgrepo.absent:
-        - ppa: jonathonf/python-2.7
-
-third-party-python-repos-absent:
-    cmd.run:
-        - name: echo 'third party python repositories purged'
-        - require:
-            - dead-snakes-are-dead
-            - jonothonf-is-missing
-
-#
-#
-#
-
 python-2.7:
     pkg.installed:
         - pkgs: 
             - python2.7
             - python-pip
-        - require:
-            - third-party-python-repos-absent
 
 # 3.5 in 16.04
 # 3.6 in 18.04
@@ -42,8 +21,6 @@ python-3:
             - python3
             - python3-pip
             - python3-venv
-        - require:
-            - third-party-python-repos-absent
 
 python-dev:
     pkg.installed:


### PR DESCRIPTION
Were originally installed by `builder` and/or formulas themselves, but after months and months they should not be around anymore. Will save 1.5 seconds on each deploy.