### PR TITLE
Provision smoke.sh with a single file

### DIFF
--- a/elife/smoke.sls
+++ b/elife/smoke.sls
@@ -1,14 +1,22 @@
-smoke.sh-repository:
-    git.latest:
-        - name: git@github.com:asm89/smoke.sh
-        - identity: {{ pillar.elife.projects_builder.key or '' }}
-        # updated to 2016-11-30
-        - rev: 34ba26aa28279dceaacd16e2b38f51cda6398853
-        - branch: master
-        - target: /opt/smoke.sh
-        - force_fetch: True
-        - force_checkout: True
-        - force_reset: True
+{% set smoke_sh_version = '34ba26aa28279dceaacd16e2b38f51cda6398853' %}
+{% set smoke_sh_hash = '39a6913a5a6808ad62a84c994b86ff07' %}
+
+smoke.sh-library:
+    file.managed:
+        - name: /opt/smoke.sh/smoke.sh
+        - source: https://raw.githubusercontent.com/asm89/smoke.sh/{{ smoke_sh_version }}/smoke.sh
+        - source_hash: md5={{ smoke_sh_hash }}
+        - user: root
+        - group: root
+        - mode: 755
+
+smoke.sh-repository-removal:
+    cmd.run:
+        - name: |
+            rm -rf .git
+            rm -f LICENSE
+            rm -f README.md
+        - cwd: /opt/smoke.sh
 
 # ensure something is always able to run even if a project has no smoke-tests.sh script
 smoke-tests-wrapper-script:

--- a/elife/smoke.sls
+++ b/elife/smoke.sls
@@ -11,6 +11,7 @@ smoke.sh-library:
         - group: root
         - mode: 755
 
+# deprecated: removed once executed everywhere
 smoke.sh-repository-removal:
     cmd.run:
         - name: |

--- a/elife/smoke.sls
+++ b/elife/smoke.sls
@@ -6,6 +6,7 @@ smoke.sh-library:
         - name: /opt/smoke.sh/smoke.sh
         - source: https://raw.githubusercontent.com/asm89/smoke.sh/{{ smoke_sh_version }}/smoke.sh
         - source_hash: md5={{ smoke_sh_hash }}
+        - makedirs: True
         - user: root
         - group: root
         - mode: 755


### PR DESCRIPTION
A repository isn't very useful for a single .sh file. Will save 3 seconds
on each deploy