### PR TITLE
Run docker-prune on each highstate

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -103,3 +103,11 @@ docker-ready:
             - docker-users-in-group
             - docker-scripts
             - docker-scripts-path
+
+# frees disk space from old images/containers/volumes/...
+# older than last X days hours and not in use
+docker-prune-last-days:
+    cmd.run:
+        - name: /usr/local/docker-scripts/docker-prune {{ 24 * pillar.elife.docker.prune_days }}
+        - require:
+            - docker-ready

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -164,6 +164,7 @@ elife:
     docker:
         username: elifealfreduser
         password: null
+        prune_days: 14
 
     gcloud:
         directory: /home/elife


### PR DESCRIPTION
Trialled in `elife-xpub`, works well and we go for a reasonable default of 14 days to avoid losing caches. Can be tuned per-project.