### PR TITLE
Remove pip.installed

### DIFF
--- a/elife/aws-cli.sls
+++ b/elife/aws-cli.sls
@@ -1,4 +1,4 @@
 aws-cli:
-    pip.installed:
-        - name: awscli
+    cmd.run:
+        - name: pip install awscli
 

--- a/elife/python.sls
+++ b/elife/python.sls
@@ -34,11 +34,9 @@ python-dev:
             - python-3
 
 global-python-requisites:
-    pip.installed:
-        #- pip_bin: /usr/bin/python2.7
-        - pkgs:
-            # DEPRECATED. installed for any remaining python 2 apps creating virtualenvs
-            - virtualenv>=13
+    cmd.run:
+        # DEPRECATED. installed for any remaining python 2 apps creating virtualenvs
+        - name: pip install "virtualenv>=13"
         - require:
             - python-2.7
 


### PR DESCRIPTION
From https://github.com/elifesciences/elife-xpub-formula/pull/51 `pip.installed` started failing (on 16.04 at least) with Salt unable to found pip. Manual testing shows pip is installed system-wide and works fine, so I'm replacing these broken states with commands.