### PR TITLE
Remove leftover pip.installed

### DIFF
--- a/elife/pypi.sls
+++ b/elife/pypi.sls
@@ -15,6 +15,5 @@ pypi-credentials-ubuntu-user:
             - deploy-user
 
 twine:
-    pip.installed:
-        - pkgs:
-            - twine
+    cmd.run:
+        - name: pip install twine

--- a/elife/uwsgi.sls
+++ b/elife/uwsgi.sls
@@ -18,8 +18,8 @@ uwsgi-pkg:
 {% else %}
 # apps should be installing and using their own version of uwsgi
 uwsgi-pkg:
-    pip.installed:
-        - name: uwsgi >= 2.0.8
+    cmd.run:
+        - name: pip install "uwsgi>=2.0.8"
         - require:
             - python-dev
         - reload_modules: True

--- a/elife/uwsgi.sls
+++ b/elife/uwsgi.sls
@@ -50,7 +50,7 @@ uwsgi-sock-dir:
         - name: /run/uwsgi/
         - user: {{ pillar.elife.webserver.username }}
         - require:
-            - pip: uwsgi-pkg
+            - uwsgi-pkg
 {% endif %}
 
 # systemd, Ubuntu 16.04+ only


### PR DESCRIPTION
Follow-up to https://github.com/elifesciences/builder-base-formula/pull/186 with the bits not strictly necessary for elife-xpub.