### PR TITLE
Pass role to assume during EKS authentication

### DIFF
--- a/elife/kubectl.sls
+++ b/elife/kubectl.sls
@@ -34,9 +34,9 @@ aws-iam-authenticator-binary:
 {% for cluster_name, cluster_configuration in pillar.elife.eks.clusters.items() %}
 aws-eks-update-kube-config-{{ cluster_name }}:
     cmd.run:
-        - name: aws eks update-kubeconfig --name {{ cluster_name }}
+        - name: aws eks update-kubeconfig --name {{ cluster_name }} --role-arn {{ cluster_configuration['role'] }}
         - env:
-            - AWS_DEFAULT_REGION: us-east-1
+            - AWS_DEFAULT_REGION: {{ cluster_configuration['region'] }}
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - kubectl-package

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -182,6 +182,7 @@ elife:
         #clusters:
         #    kubernetes--demo:
         #        region: us-east-1 
+        #        role: arn:aws:iam::512686554592:role/kubernetes--demo--AmazonEKSUserRole 
 
     external_volume:
         device: /dev/xvdh


### PR DESCRIPTION
The easiest way to use IAM to authenticate is to make users assume a role. This makes it automated whenever `kubectl` will be used