### PR TITLE
Use docker version to probe daemon readiness

### DIFF
--- a/elife/docker-scripts/docker-wait-daemon
+++ b/elife/docker-scripts/docker-wait-daemon
@@ -2,14 +2,7 @@
 set -e
 
 timeout="${1:-120}"
-socket="/var/run/docker.sock"
 
-echo "Waiting for socket $socket to be writable"
-# similar to elife/utils/wait_for_port,
-# poll until a connection to the docker daemon can be established
-# - connect and time out after 1 seconds (-w)
-# - wait for 0 seconds (-q)
-# - use Unix sockets rather than hosts and ports (-U)
-# - silence stdout and stderr
-timeout "$timeout" sh -c "while ! nc -q0 -w1 -U $socket </dev/null >/dev/null 2>&1; do sleep 1; done"
-echo "Connection was established on $socket"
+echo "Waiting for daemon to answer requests"
+timeout "$timeout" sh -c "while ! docker version; do sleep 5; done"
+echo "Daemon is up and running"


### PR DESCRIPTION
From https://github.com/elifesciences/elife-xpub/pull/1071

`/var/run/docker.sock` seems to be left over when the daemon is stopped, and the other file in there (`docker.pid`) is created too soon. `docker version` is the ultimate judge of whether the daemon can answer requests.