### PR TITLE
Add support for mockserver

### DIFF
--- a/elife/config/home-deploy-user-mockserver-docker-compose.yml
+++ b/elife/config/home-deploy-user-mockserver-docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+    app:
+        image: jamesdbloom/mockserver
+        ports:
+            # avoid clash with mailcatcher
+            - 2080:1080
+        restart: always
+    configure:
+        image: appropriate/curl
+        entrypoint: /bin/sh -c "
+            while ! nc -z app 1080; do sleep 1; done;
+            find /expectations -name '*.sh' -exec sh {} \; ;
+            exec sleep 365d"
+        volumes:
+            - ./expectations/:/expectations
+        restart: always
+        depends_on:
+            - app

--- a/elife/mockserver.sls
+++ b/elife/mockserver.sls
@@ -1,0 +1,29 @@
+docker-compose-mockserver:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/mockserver/docker-compose.yml
+        - source: salt://elife/config/home-deploy-user-mockserver-docker-compose.yml
+        - user: {{ pillar.elife.deploy_user.username }}
+        - template: jinja
+        - makedirs: True
+        - require: 
+            - deploy-user
+            - docker-ready
+
+{% for name, file in pillar.elife.mockserver.expectations.items() %}
+docker-compose-mockserver-expectations-{{ name }}:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/mockserver/expectations/{{ name }}.sh
+        - source: {{ file }}
+        - user: {{ pillar.elife.deploy_user.username }}
+        - mode: 755
+        - makedirs: True
+        - require: 
+            - docker-compose-mockserver
+{% endfor %}
+
+docker-compose-mockserver-up:
+    cmd.run:
+        - name: /usr/local/bin/docker-compose -f docker-compose.yml up --force-recreate -d
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}/mockserver
+        - require: 
+            - docker-compose-mockserver

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -252,6 +252,10 @@ elife:
             #    port: 8001
             #    enabled: True
 
+    mockserver:
+        expectations: {}
+            #elife_bot: salt://elife-bot/config/mockserver.sh
+
     forced_dns: {}
 
     coveralls:


### PR DESCRIPTION
[MockServer](https://mock-server.com/) is a dynamically configurable web service that can server as a fake implementation for external services in testing environments.