### PR TITLE
Extract first nginx macro

### DIFF
--- a/elife/nginx-macros.sls
+++ b/elife/nginx-macros.sls
@@ -1,0 +1,10 @@
+{% macro consumer_groups_filter(users) -%}
+variables_hash_max_size 2048; # to fit this map
+map_hash_bucket_size 128;
+map $http_authorization $consumer_groups_filtered {
+    default    "";
+    {%- for i, user in users.items() -%}
+    "Basic {{ salt['hashutil.base64_b64encode'](user['username'] ~ ':' ~ user['password']) }}" $http_x_consumer_groups;
+    {%- endfor -%}
+}
+{%- endmacro -%}

--- a/elife/nginx-macros.sls
+++ b/elife/nginx-macros.sls
@@ -1,4 +1,8 @@
 {% macro consumer_groups_filter(users) -%}
+# Authenticates the api-gateway.
+# Copies a filtered version of the api-gateway X-Consumer-Groups header
+# into X-Consumer-Groups-Filtered, only allowing the client to specify the
+# header if it carries an Authorization header too
 variables_hash_max_size 2048; # to fit this map
 map_hash_bucket_size 128;
 map $http_authorization $consumer_groups_filtered {


### PR DESCRIPTION
Black magic to extract [this other piece of black magic](https://github.com/elifesciences/lax-formula/blob/master/salt/lax/config/etc-nginx-sitesavailable-lax.conf#L18-L25) and make it reusable from other formulas (in this case `journal-cms`).

[Macros official documentation](https://docs.saltstack.com/en/2017.7/topics/jinja/index.html#macros) is available. The backlinked PR on `lax-formula` shows how to use this.