### PR TITLE
Run docker-prune in a cron

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -111,3 +111,11 @@ docker-prune-last-days:
         - name: /usr/local/docker-scripts/docker-prune {{ 24 * pillar.elife.docker.prune_days }}
         - require:
             - docker-ready
+
+docker-prune-last-days-cron:
+    cron.present:
+        - identifier: docker-prune-last-days
+        - name: /usr/local/docker-scripts/docker-prune {{ 24 * pillar.elife.docker.prune_days }}
+        - minute: random
+        - require:
+            - docker-ready


### PR DESCRIPTION
Should help with failures like https://alfred.elifesciences.org/blue/organizations/jenkins/pull-requests-projects%2Felife-xpub/detail/PR-1386/6/pipeline/ 

The prune of unused images happens when a new Salt highstate on the server is executed. For servers where applications are deployed this is on every build, but for Jenkins-managed nodes this doesn't happen anymore: eventually their 100GB disk gets full.

The Jenkins nodes aren't always running, but running them hourly (at a random minute) is a best-effort way to perform the cleanup. This shouldn't cause unwanted interactions with builds that are creating or using images, since the targeted images are the unused ones.