### PR TITLE
Feature: sets 'fs_passno' to '2' on external volumes 

### DIFF
--- a/elife/external-volume.sls
+++ b/elife/external-volume.sls
@@ -29,6 +29,7 @@ mount-external-volume:
         - mkmnt: True
         - opts:
             - defaults
+        - pass_num: 2 # fsck ext volume on reboot
         - require:
             - format-external-volume
             - mount-point-external-volume


### PR DESCRIPTION
This is so they get checked (if necessary) on reboot.

I've never done this with AWS/ec2 before and the volumes we have tend to be smallish compared so I'm not sure how much downtime might be incurred while the fs is chk'ed.