### PR TITLE
Fix: painless systemd+uwsgi restarts

### DIFF
--- a/elife/config/lib-systemd-system-uwsgi-service.service
+++ b/elife/config/lib-systemd-system-uwsgi-service.service
@@ -6,6 +6,8 @@ After=network.target
 WantedBy=multi-user.target
 
 [Service]
+User={{ pillar.elife.webserver.username }}
+Group={{ pillar.elife.webserver.username }}
 KillSignal=SIGQUIT
 Type=notify
 Restart=on-failure
@@ -14,5 +16,5 @@ Environment="LANG=en_US.UTF-8"
 Environment="NEW_RELIC_CONFIG_FILE={{ folder }}/newrelic.ini"
 ExecStart={{ folder }}/venv/bin/newrelic-admin run-program {{ folder }}/venv/bin/uwsgi --enable-threads --ini {{ folder }}/uwsgi.ini
 {% else %}
-ExecStart={{ folder }}/venv/bin/uwsgi --ini {{ folder }}/uwsgi.ini
+ExecStart={{ folder }}/venv/bin/uwsgi --ini {{ folder }}/uwsgi.ini --logto /var/log/uwsgi.log
 {% endif %}

--- a/elife/config/lib-systemd-system-uwsgi.socket
+++ b/elife/config/lib-systemd-system-uwsgi.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Socket for uwsgi-{{ name }}.service
+
+[Socket]
+ListenStream=/var/run/uwsgi/{{ name }}.socket
+SocketUser={{ pillar.elife.webserver.username }}
+SocketGroup={{ pillar.elife.webserver.username }}
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
I don't think anything is using systemd+uwsgi, but if they are then they're probably having problems with `systemctl restart servicename` timing out (minutes?), force killing the process and only then restarting.

This is the approach recommended by uwsgi, albeit not using systemd templates: 
https://uwsgi-docs.readthedocs.io/en/latest/Systemd.html#one-service-per-app-in-systemd

These `.socket` files can be treated just like services by Salt.

The log file appears to be owned and writeable by root only, even though uwsgi is supposed to be dropping privileges to the www-user, so not sure what is going on there. I think deferring the privilege dropping to systemd is the best choice here. uwsgi's 'emperor' mode that acts as a process manager for multiple uwsgi applications may be blurring the line between upstart/systemd and uwsgi. Cool feature though.

I have elife-metrics using [this approach](https://github.com/elifesciences/elife-metrics-formula/pull/3) nicely.