### PR TITLE
Feature: uwsgi.sls, adds ability to disable newrelic for specific uwsgi services

### DIFF
--- a/elife/config/lib-systemd-system-uwsgi-service.service
+++ b/elife/config/lib-systemd-system-uwsgi-service.service
@@ -12,9 +12,9 @@ KillSignal=SIGQUIT
 Type=notify
 Restart=on-failure
 Environment="LANG=en_US.UTF-8"
-{% if pillar.elife.newrelic.enabled %}
+{% if pillar.elife.newrelic.enabled and not disable_newrelic %}
 Environment="NEW_RELIC_CONFIG_FILE={{ folder }}/newrelic.ini"
-ExecStart={{ folder }}/venv/bin/newrelic-admin run-program {{ folder }}/venv/bin/uwsgi --enable-threads --ini {{ folder }}/uwsgi.ini
+ExecStart={{ folder }}/venv/bin/newrelic-admin run-program {{ folder }}/venv/bin/uwsgi --enable-threads --ini {{ folder }}/uwsgi.ini --socket /var/run/uwsgi/{{ name }}.socket --logto /var/log/uwsgi-{{ name }}.log
 {% else %}
-ExecStart={{ folder }}/venv/bin/uwsgi --ini {{ folder }}/uwsgi.ini  --socket /var/run/uwsgi/{{ name }}.socket --logto /var/log/uwsgi.log
+ExecStart={{ folder }}/venv/bin/uwsgi --ini {{ folder }}/uwsgi.ini --socket /var/run/uwsgi/{{ name }}.socket --logto /var/log/uwsgi-{{ name }}.log
 {% endif %}


### PR DESCRIPTION
came about because I forgot to update bot-lax in the lax formula and bot-lax doesn't appear to support newrelic (yet). it probably should. another ticket perhaps.

edit: it also adds the `--socket` and `--log-to` params for newrelic-enabled services that I appear to have left out of previous commits