### PR TITLE
Docker 18.09.3 upgrade and pin

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -52,7 +52,7 @@ docker-packages:
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
             {% elif salt['grains.get']('oscodename') == 'xenial' %}
-            - docker-ce: 18.09.3~3-0~ubuntu-xenial
+            - docker-ce: 18.09.3
             {% else %}
             # TODO: pin
             - docker-ce: 18.09.3

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -52,7 +52,7 @@ docker-packages:
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
             {% else %}
-            - docker-ce
+            - docker-ce: 18.09.3~3-0~ubuntu
             {% endif %}
         - refresh: True
         - require:

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -51,8 +51,11 @@ docker-packages:
             # poorly-patched vulnerability 'fix' breaks 3.3 kernels, like the one in the Ubuntu Trusty 14.04 LTS
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
+            {% elif salt['grains.get']('oscodename') == 'xenial' %}
+            - docker-ce: 18.09.3~3-0~ubuntu-xenial
             {% else %}
-            - docker-ce: 18.09.3~3-0~ubuntu
+            # TODO: pin
+            - docker-ce: 18.09.3
             {% endif %}
         - refresh: True
         - require:


### PR DESCRIPTION
Includes https://github.com/moby/moby/issues/38249#issuecomment-474795342 which has been afflicting `elife-xpub`.