### PR TITLE
Docker upgrade on >= 16.04

### DIFF
--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -52,7 +52,7 @@ docker-packages:
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
             {% elif salt['grains.get']('oscodename') == 'xenial' %}
-            - docker-ce: 18.09.3~3-0~ubuntu-xenial
+            - docker-ce: 18.09.3
             {% else %}
             # TODO: pin
             - docker-ce: 18.09.3

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -60,11 +60,14 @@ docker-packages:
             - docker-repository
 
     # hack. 16.04 and 18.04 are affected by a bug that disappears after a service restart
+    # https://github.com/moby/moby/issues/38249#issuecomment-474795342
     {% if salt['grains.get']('oscodename') != 'trusty' %}
     cmd.run:
-        - name: systemctl stop docker || echo "failed to restart (which is fine)"
+        - name: systemctl stop docker
         - require_in:
             - service: docker-packages
+        #- onlyif:
+        #    older version present. are we ok restarting docker on every highstate until this bug is fixed?
     {% endif %}
 
     service.running:

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -52,7 +52,7 @@ docker-packages:
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
             {% else %}
-            - docker-ce
+            - docker-ce: 18.09.3~3-0~ubuntu
             {% endif %}
         - refresh: True
         - require:

--- a/elife/docker.sls
+++ b/elife/docker.sls
@@ -51,8 +51,11 @@ docker-packages:
             # poorly-patched vulnerability 'fix' breaks 3.3 kernels, like the one in the Ubuntu Trusty 14.04 LTS
             {% if salt['grains.get']('oscodename') == 'trusty' %}
             - docker-ce: 18.06.1~ce~3-0~ubuntu
+            {% elif salt['grains.get']('oscodename') == 'xenial' %}
+            - docker-ce: 18.09.3~3-0~ubuntu-xenial
             {% else %}
-            - docker-ce: 18.09.3~3-0~ubuntu
+            # TODO: pin
+            - docker-ce: 18.09.3
             {% endif %}
         - refresh: True
         - require:


### PR DESCRIPTION
cc @giorgiosironi 

the bug mentions the problem disappears on service restart. If you're not ok with restarting docker on every highstate, we could find a condition that looks for a specific versions of the library, or only restart if the package gets updated, or ...