### PR TITLE
Feature: postgresql now has entries for localhost and rds, if rds exists

### DIFF
--- a/elife/postgresql.sls
+++ b/elife/postgresql.sls
@@ -12,12 +12,19 @@ pgpass-file:
             pass: {{ pillar.elife.db_root.password }}
             host: localhost
             port: 5432
-        {% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
-        - context:
+
+{% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
+pgpass-rds-entry:
+    file.append:
+        - name: /root/.pgpass
+        - source: salt://elife/config/root-pgpass
+        - template: jinja
+        - defaults:
+            user: {{ pillar.elife.db_root.username }}
             pass: {{ salt['elife.cfg']('project.rds_password') }}
             host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') }}
             port: {{ salt['elife.cfg']('cfn.outputs.RDSPort') }}
-        {% endif %}
+{% endif %}
 
 postgresql:
     pkg.installed:


### PR DESCRIPTION
this means the db root user can always access local databases, even if the main database is on RDS.

this covers the case where both local and remote db servers are in play (elife-dashboard)