### PR TITLE
Disable docker network prune

### DIFF
--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -5,7 +5,8 @@ set -e
 hours_limit="${1:-336}"
 
 docker container prune --force
-docker network prune --force
+# disabled due to race condition with `docker-compose up`
+# docker network prune --force
 docker volume prune --force
 
 echo "Clean up all images not used in the last $hours_limit hours"


### PR DESCRIPTION
Possibly this should use `--filter until=` but unclear if that is working as we want on images, so not expanding its use.

Disk space difference should be minimal (bytes).