### PR TITLE
Feature: application certificate overrides

### DIFF
--- a/elife/certificates.sls
+++ b/elife/certificates.sls
@@ -22,18 +22,20 @@ web-certificates-dir:
             - web-certificates-group
 
 {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
+{% set app = pillar.elife.certificates.app or 'elife' %}
+
 web-certificate-file:
     file.managed:
         - name: /etc/certificates/certificate.crt
         - group: {{ pillar.elife.certificates.username }}
-        - source: salt://elife/config/etc-certificates-certificate.crt
+        - source: salt://{{ app }}/config/etc-certificates-certificate.crt
         - require:
             - file: web-certificates-dir
 
 web-private-key:
     file.managed:
         - name: /etc/certificates/privkey.pem
-        - source: salt://elife/config/etc-certificates-privkey.pem
+        - source: salt://{{ app }}/config/etc-certificates-privkey.pem
         - group: {{ pillar.elife.certificates.username }}
         - require:
             - file: web-certificates-dir
@@ -41,7 +43,7 @@ web-private-key:
 web-fullchain-key:
     file.managed:
         - name: /etc/certificates/fullchain.pem
-        - source: salt://elife/config/etc-certificates-fullchain.pem
+        - source: salt://{{ app }}/config/etc-certificates-fullchain.pem
         - group: {{ pillar.elife.certificates.username }}
         - require:
             - file: web-certificates-dir

--- a/elife/nginx.sls
+++ b/elife/nginx.sls
@@ -74,23 +74,6 @@ redirect-nginx-http-to-https:
 include:
     - .certificates
 
-{% if salt['grains.get']('osrelease') == '18.04' %}
-# just a test. this problem only affects redirects so far
-# if it works, I'll roll it out to builder-base in a nicer fashion
-# https://bugs.launchpad.net/ubuntu/+source/nginx/+bug/1581864
-nginx-systemd-hack:
-    cmd.run:
-        - name: |
-            set -e
-            mkdir -p /etc/systemd/system/nginx.service.d
-            printf "[Service]\nExecStartPost=/bin/sleep 0.1\n" > /etc/systemd/system/nginx.service.d/override.conf
-            systemctl daemon-reload
-        #- unless: # override exists
-        #    - test -e /etc/systemd/system/nginx.service.d/override.conf
-        - require:
-            - nginx-config
-{% endif %}
-
 #
 # service
 #

--- a/elife/nginx.sls
+++ b/elife/nginx.sls
@@ -74,7 +74,22 @@ redirect-nginx-http-to-https:
 include:
     - .certificates
 
-
+{% if salt['grains.get']('osrelease') == '18.04' %}
+# just a test. this problem only affects redirects so far
+# if it works, I'll roll it out to builder-base in a nicer fashion
+# https://bugs.launchpad.net/ubuntu/+source/nginx/+bug/1581864
+nginx-systemd-hack:
+    cmd.run:
+        - name: |
+            set -e
+            mkdir -p /etc/systemd/system/nginx.service.d
+            printf "[Service]\nExecStartPost=/bin/sleep 0.1\n" > /etc/systemd/system/nginx.service.d/override.conf
+            systemctl daemon-reload
+        #- unless: # override exists
+        #    - test -e /etc/systemd/system/nginx.service.d/override.conf
+        - require:
+            - nginx-config
+{% endif %}
 
 #
 # service

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -80,6 +80,8 @@ elife:
         certificate_folder: /etc/certificates
 
     certificates:
+        # allows per-application certificate overrides. see elife/certificates.sls
+        app: elife # the builder-base 'elife' application root
         username: www-data
 
     web_users:


### PR DESCRIPTION
* adds support for applications to switch in their own certificates by overriding a pillar default
* default set of certificates are those provided by builder-private ('elife')