### PR TITLE
Feature: adds missing description of newrelic_python pillar data

### DIFF
--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -143,6 +143,11 @@ elife:
         rest_api_key: null
         insights_api_key: null
 
+    newrelic_python: {}
+        #application_folder: /srv/elife-metrics
+        #service: uwsgi-elife-metrics
+        #dependency_state: configure-elife-metrics
+
     # postfix using AWS SES as a backend
     postfix_ses_mail:
         smtp: email-smtp.us-east-1.amazonaws.com # change region to suit


### PR DESCRIPTION
if we want article-scheduler to have newrelic support (we may not) then I'll need to make newrelic_python.sls multi-app like the `uwsgi` pillar data