### PR TITLE
Feature: php fpm 7.2 fixes

### DIFF
--- a/elife/config/etc-php-7.2-fpm-pool.d-www.conf
+++ b/elife/config/etc-php-7.2-fpm-pool.d-www.conf
@@ -33,7 +33,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php7.0-fpm.sock
+listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/elife/php7.sls
+++ b/elife/php7.sls
@@ -31,8 +31,10 @@ php-ppa:
 
 {% else %}
 
-# still problematic in 16.04:
+# note: still problematic in 16.04:
 # https://github.com/saltstack/salt/issues/32294
+
+# note: see nginx-php7.sls for /var/php-fpm.sock configuration
 
 php-ppa:
     cmd.run:


### PR DESCRIPTION
cc @giorgiosironi 

an incorrect path caused the php-fpm sock file to be created with the wrong name. This caused a clever symlink in php7.sls to be broken. The personalised-covers nginx config was pointing to the symlink and refused to start