### PR TITLE
Fix: newrelic_python further restricted

### DIFF
--- a/elife/newrelic-python.sls
+++ b/elife/newrelic-python.sls
@@ -9,7 +9,7 @@
 # - pillar.elife.newrelic_python.service 
 #     the name of a service.running state that should be restarted
 
-{% if pillar.elife.newrelic.enabled %}
+{% if pillar.elife.newrelic.enabled and pillar.elife.newrelic_python %}
 newrelic-python-license-configuration:
     cmd.run:
         - name: venv/bin/newrelic-admin generate-config {{ pillar.elife.newrelic.license }} newrelic.ini

--- a/elife/newrelic-python.sls
+++ b/elife/newrelic-python.sls
@@ -9,7 +9,14 @@
 # - pillar.elife.newrelic_python.service 
 #     the name of a service.running state that should be restarted
 
-{% if pillar.elife.newrelic.enabled and pillar.elife.newrelic_python %}
+{% if pillar.elife.newrelic.enabled %}
+    {% if not pillar.elife.newrelic_python %}
+
+newrelic_python misconfigured:
+    cmd.run:
+        - name: echo "pillar data misconfigured, could not find 'pillar.elife.newrelic_python'" && false
+
+    {% else %}
 newrelic-python-license-configuration:
     cmd.run:
         - name: venv/bin/newrelic-admin generate-config {{ pillar.elife.newrelic.license }} newrelic.ini
@@ -56,4 +63,5 @@ newrelic-python-logfile-agent-in-ini-configuration:
         - listen_in:
             - service: {{ pillar.elife.newrelic_python.service }}
         {% endif %}
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
* `newrelic_python.sls` states only available if newrelic enabled AND newrelic_python configuration available.

we had a highstate failure in `elife-dashboard--prod` with:

```
local:
    Data failed to compile:
----------
    Rendering SLS 'base:elife.newrelic-python' failed: Jinja variable 'dict object' has no attribute 'newrelic_python'
```

because the `elife.newrelic_python` state had been included in the `top.sls` file but no `pillar.elife.newrelic_python` configuration made available.

I know it says *right at the top of the file* that the state file cannot be included without also specifying [...] but this would change it from a hard failure with an esoteric message to a failed state with a descriptive error message.

Not sure which approach is better, feel free to close if you prefer the original way