### PR TITLE
Remove race conditions from docker-prune

### DIFF
--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -3,6 +3,20 @@ set -e
 
 # default: 14 days
 hours_limit="${1:-336}"
+# default: 80%
+usage_limit="${2:-80}"
+
+if [ -z "$FORCE" ]; then
+    echo "Usage limit: ${usage_limit}%"
+    disk_space_used=$(df --output=pcent /var/lib/docker | sed 1d | sed -e 's/%//g')
+    echo "Disk space used: ${disk_space_used}%"
+    disk_inodes_used=$(df --output=ipcent /var/lib/docker | sed 1d | sed -e 's/%//g')
+    echo "Disk inodes used: ${disk_inodes_used}%"
+    if [ "$disk_space_used" -lt "$usage_limit" -a "$disk_inodes_used" -lt "$usage_limit" ]; then
+        echo "Not necessary to run because of low usage"
+        exit 0
+    fi
+fi
 
 echo "Clean up all stopped containers older than the last $hours_limit hours"
 docker container prune --filter "until=${hours_limit}h" --force

--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -4,8 +4,13 @@ set -e
 # default: 14 days
 hours_limit="${1:-336}"
 
+echo "Clean up all stopped containers older than the last $hours_limit hours"
 docker container prune --filter "until=${hours_limit}h" --force
+
+echo "Clean up all unused networks older than the last $hours_limit hours"
 docker network prune --filter "until=${hours_limit}h" --force
+
+echo "Clean up all unused volumes"
 # doesn't support --filter "until=..."
 # but should only be unused volumes anyway
 docker volume prune --force

--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -7,6 +7,7 @@ hours_limit="${1:-336}"
 docker container prune --filter "until=${hours_limit}h" --force
 docker network prune --filter "until=${hours_limit}h" --force
 # doesn't support --filter "until=..."
+# but should only be unused volumes anyway
 docker volume prune --force
 
 echo "Clean up all images not used in the last $hours_limit hours"

--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -15,5 +15,5 @@ echo "Clean up all unused volumes"
 # but should only be unused volumes anyway
 docker volume prune --force
 
-echo "Clean up all images not used in the last $hours_limit hours"
-docker image prune --all --filter "until=${hours_limit}h" --force
+echo "Clean up all images not referenced by a container"
+docker image prune --all --force

--- a/elife/docker-scripts/docker-prune
+++ b/elife/docker-scripts/docker-prune
@@ -4,9 +4,9 @@ set -e
 # default: 14 days
 hours_limit="${1:-336}"
 
-docker container prune --force
-# disabled due to race condition with `docker-compose up`
-# docker network prune --force
+docker container prune --filter "until=${hours_limit}h" --force
+docker network prune --filter "until=${hours_limit}h" --force
+# doesn't support --filter "until=..."
 docker volume prune --force
 
 echo "Clean up all images not used in the last $hours_limit hours"


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4850

This version is still aggressive on image removal as it will remove any image as long as there is no container running with it. The date filter is not really useful because it refers to the image _creation_ date, which for any deployment may be far in the past (e.g. `elifesciences/sciencebeam:0.0.1`)

We counteract this fact by only cleaning if it is necessary i.e. if more than 80% of space or inodes are being used at the moment.