### PR TITLE
re-enables postgresql pg_hba conf on mixed local+rds instances

### DIFF
--- a/elife/postgresql.sls
+++ b/elife/postgresql.sls
@@ -48,6 +48,7 @@ postgresql:
             - pgpass-file
 {% endif %}
 
+# TODO: remove this, not used in 16.04+, uncertain about 14.04
 {% if not salt['elife.cfg']('cfn.outputs.RDSHost') %}
 postgresql-init:
     file.managed:
@@ -57,6 +58,7 @@ postgresql-init:
             - pkg: postgresql
         - require_in:
             - cmd: postgresql-ready
+{% endif %}
 
 postgresql-config:
     file.managed:
@@ -68,7 +70,6 @@ postgresql-config:
             - service: postgresql
         - require_in:
             - cmd: postgresql-ready
-{% endif %}
 
 {% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
 # create the not-quite-super RDS user


### PR DESCRIPTION
no harm in that conf file sitting there if the service is dead

this is for elife-dashboard where, for some unholy reason, this has gone undetected since *forever*. 

cc @giorgiosironi - if this is green I'll merge it in so I can finish off `--end2end` and (hopefully) `--prod` before the UK wakes up for work