### PR TITLE
postgresql 'pg_hba.conf' file always present, even if service is dead

### DIFF
--- a/elife/postgresql.sls
+++ b/elife/postgresql.sls
@@ -57,6 +57,7 @@ postgresql-init:
             - pkg: postgresql
         - require_in:
             - cmd: postgresql-ready
+{% endif %}
 
 postgresql-config:
     file.managed:
@@ -68,7 +69,6 @@ postgresql-config:
             - service: postgresql
         - require_in:
             - cmd: postgresql-ready
-{% endif %}
 
 {% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
 # create the not-quite-super RDS user


### PR DESCRIPTION
on dual local+rds instances, the local `pg_hba.conf` file was left unmanaged. 

this file had probably been tweaked by hand (changing 'peer' to 'md5') to get it 'working' previously