### PR TITLE
Upgrade hub to 2.11.2

### DIFF
--- a/elife/hub.sls
+++ b/elife/hub.sls
@@ -1,11 +1,13 @@
 # official command line tool to interact with Github's API
 
+{% set hub_version = '2.11.2' %}
+
 hub:
     cmd.run:
         - name: |
-            wget -c https://github.com/github/hub/releases/download/v2.2.9/hub-linux-amd64-2.2.9.tgz
-            tar zvxf hub-linux-amd64-2.2.9.tgz
-            ln -sf /opt/hub-linux-amd64-2.2.9/bin/hub /usr/local/bin/hub
+            wget -c https://github.com/github/hub/releases/download/v{{ hub_version }}/hub-linux-amd64-{{ hub_version }}.tgz
+            tar zvxf hub-linux-amd64-{{ hub_version }}.tgz
+            ln -sf /opt/hub-linux-amd64-{{ hub_version }}/bin/hub /usr/local/bin/hub
         - cwd: /opt
         - unless:
             - which hub


### PR DESCRIPTION
Development seem to have resumed in the second part of 2018