### PR TITLE
Fix: adds 'openjdk8.sls' statefile as a replacement for 'java8.sls'

### DIFF
--- a/elife/openjdk8.sls
+++ b/elife/openjdk8.sls
@@ -19,6 +19,8 @@ oracle-java8-installer-removal:
 openjdk8 ppa:
     pkgrepo.managed:
         - ppa: jonathonf/openjdk
+        - require_in:
+            - pkg: java8
         
 {% endif %}
 

--- a/elife/openjdk8.sls
+++ b/elife/openjdk8.sls
@@ -1,0 +1,35 @@
+# 14.04, 16.04 and 18.04 have a "openjdk-8-jre-headless" package
+# 14.04 requires a ppa
+
+# remove oracle java (if it exists)
+
+oracle-ppa-removal:
+    pkgrepo.absent:
+        # https://docs.saltstack.com/en/latest/ref/states/all/salt.states.pkgrepo.html#salt.states.pkgrepo.absent
+        - ppa: webupd8team/java # no idea if this is correct
+
+oracle-java8-installer-removal:
+    pkg.purged:
+        - name: oracle-java8-installer
+        - require:
+            - oracle-ppa-removal
+
+{% if salt['grains.get']('osrelease') == "14.04" %}
+
+openjdk8 ppa:
+    pkgrepo.managed:
+        - ppa: jonathonf/openjdk
+        
+{% endif %}
+
+java8:
+    pkg.installed:
+        - pkgs: 
+            - openjdk-8-jre-headless
+        - require:
+            - oracle-java8-installer-removal
+        
+    cmd.run:
+        - name: echo "java8 installed"
+        - require:
+            - pkg: java8


### PR DESCRIPTION
oracle java 8 on 14.04 [is now completely broken](https://launchpad.net/~webupd8team/+archive/ubuntu/java), rather than just 'kinda broken', and is preventing the `search` project from passing tests.

This new state file is intended as a replacement for the `java8.sls`.

Works for me locally on 14.04 and 18.04 using a tweaked basebox.
