### PR TITLE
Feature: systemd multi-process test demonstration

### DIFF
--- a/elife/config/lib-systemd-system-test.service
+++ b/elife/config/lib-systemd-system-test.service
@@ -1,0 +1,12 @@
+[Unit]
+Description="{{ process }}"
+After=network.target
+PartOf={{ process }}-controller.target
+#RefuseManualStart=, # mght be useful as well
+
+[Install]
+WantedBy={{ process }}-controller.target
+
+[Service]
+RestartSec=10
+ExecStart=/usr/bin/python3 /opt/{{ process }}.py $I

--- a/elife/multi-process-test.sls
+++ b/elife/multi-process-test.sls
@@ -1,0 +1,48 @@
+
+# test that N processes are brought using a single service state
+# each process simply writes it's identifier and the time to the syslog
+
+{% set process = "test" %}
+{% set num_processes = 10 %}
+
+/opt/{{ process }}.py:
+    file.managed:
+        - source: salt://elife/scripts/test.py
+
+{{ process }}:
+    file.managed:
+        - name: /lib/systemd/system/{{ process }}@.service
+        - source: salt://elife/config/lib-systemd-system-test.service
+        - template: jinja
+        - context:
+            process: {{ process }}
+        - require:
+            - /opt/{{ process }}.py
+
+    # neccessary because salt mangles "service@{x..y}" to "service@\x7bx..y\x7d.service" 
+    # systemd will see that as just a single instantiated service
+    cmd.run:
+        - name: |
+            set -e
+            systemctl disable {{ process }}@{0..99} # disable all instances (up to 99). implicit reload
+            systemctl enable {{ process }}@{0..1} # enable just the range we're after. implicit reload
+        - require:
+            - file: {{ process }}
+        # only run command if there are disabled instances in our range
+        # todo: only runs if range grows. if range shrinks to 0..0 from 0..1 then this command won't be triggered
+        - onlyif:
+            - systemctl is-enabled {{ process }}@{0..1} | grep -q 'disabled'
+
+{{ process }}-controller.target:
+    file.managed:
+        - name: /lib/systemd/system/{{ process }}-controller.target
+        - source: salt://elife/templates/process-controller.target
+
+    service.running:
+        - enable: true
+        - require:
+            - file: {{ process }}-controller.target
+            - cmd: {{ process }}
+        # restarts target (and all processes that need that target) when processes enabled
+        - watch:
+            - cmd: {{ process }}

--- a/elife/multi-process-test.sls
+++ b/elife/multi-process-test.sls
@@ -1,15 +1,18 @@
 
-# test that N processes are brought using a single service state
-# each process simply writes it's identifier and the time to the syslog
+# systemd managed group processes
+
+# 1. N number of the given process are running
+# 2. the pool of processes can be grown or shrunk
+# 3. broken processes fail highstate as they ordinarily would
 
 {% set process = "test" %}
-{% set num_processes = 10 %}
+{% set num_processes = 0 %}
 
 /opt/{{ process }}.py:
     file.managed:
         - source: salt://elife/scripts/test.py
 
-{{ process }}:
+{{ process }}-template:
     file.managed:
         - name: /lib/systemd/system/{{ process }}@.service
         - source: salt://elife/config/lib-systemd-system-test.service
@@ -19,20 +22,11 @@
         - require:
             - /opt/{{ process }}.py
 
-    # neccessary because salt mangles "service@{x..y}" to "service@\x7bx..y\x7d.service" 
-    # systemd will see that as just a single instantiated service
-    cmd.run:
-        - name: |
-            set -e
-            systemctl disable {{ process }}@{0..99} # disable all instances (up to 99). implicit reload
-            systemctl enable {{ process }}@{0..1} # enable just the range we're after. implicit reload
-        - require:
-            - file: {{ process }}
-        # only run command if there are disabled instances in our range
-        # todo: only runs if range grows. if range shrinks to 0..0 from 0..1 then this command won't be triggered
-        - onlyif:
-            - systemctl is-enabled {{ process }}@{0..1} | grep -q 'disabled'
+#
+#
+#
 
+# ensure the target state is available and running
 {{ process }}-controller.target:
     file.managed:
         - name: /lib/systemd/system/{{ process }}-controller.target
@@ -42,7 +36,36 @@
         - enable: true
         - require:
             - file: {{ process }}-controller.target
-            - cmd: {{ process }}
-        # restarts target (and all processes that need that target) when processes enabled
-        - watch:
-            - cmd: {{ process }}
+
+# ensure precisely N processes are enabled. restart controller if N has changed
+# enabled processes are started when the controller state changes
+{{ process }}-set-enabled:
+    cmd.run:
+        - name: |
+            set -e
+            systemctl stop {{ process }}@{0..99} # stop any running instances of this service.
+            systemctl disable {{ process }}@ # disable *everything*. implicit reload
+            {% if num_processes > 0 %}
+            systemctl enable {{ process }}@{0..{{ num_processes - 1}}} # enable just the range we're after. implicit reload
+            {% endif %}
+        - require:
+            - file: {{ process }}-template
+        - onlyif:
+            # only run command when the expected number of processes (enabled and running) is not equal to the intended 
+            # number of processes. 
+            # use 'is-enabled' to find enabled units. it conveniently returns 'disabled' if all are disabled, so grep for 'enabled'
+            # use 'show' and grep for the pid for running units. it conveniently returns MainPID=0 for enabled-but-not-running units
+            - test {{ num_processes }} != $(systemctl is-enabled {{ process }}@{0..99} | grep 'enabled' | wc -l) || \
+              test {{ num_processes }} != $(systemctl show {{ process }}@{0..99} | grep '^MainPID=[^0]' | wc -l)
+        - watch_in:
+            - service: {{ process }}-controller.target
+
+# ensure N processes are running 
+{% for i in range(0, num_processes) %}
+{{ process }}@{{ i }}:
+    service.running:
+        - enable: true # redundant, but can't hurt
+        - require:
+            - {{ process }}-set-enabled
+            - {{ process }}-controller.target
+{% endfor %}

--- a/elife/scripts/test.py
+++ b/elife/scripts/test.py
@@ -1,0 +1,14 @@
+import syslog
+import os
+import sys
+import time
+
+pid = os.getpid()
+aid = sys.argv[1:2]
+
+iteration=0
+while True:
+    iteration += 1
+    message = "aid: %s, pid: %s, iteration: %s" % (aid, pid, iteration)
+    syslog.syslog(message)
+    time.sleep(5)

--- a/elife/templates/process-controller.target
+++ b/elife/templates/process-controller.target
@@ -1,0 +1,2 @@
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
cc @giorgiosironi 

a demonstration of managing a group of services using a `.target` unit. It works really well but is not perfect yet.

I want to:
* avoid restarting the service on daily highstate
* grow/shrink the number of processes and have the right things enabled/disabled/restarted

Turns out salt mangles service names that look like "service@{x..y}" so can't use the `service` state with the individual processes, which shouldn't be a problem if they're being treated as a group using the controller service.