### PR TITLE
Add git author to Jenkins nodes

### DIFF
--- a/elife/jenkins-node.sls
+++ b/elife/jenkins-node.sls
@@ -63,8 +63,14 @@ jenkins-workspaces-cleanup-cron:
         - hour: 5
         - minute: 0
 
-add-jenkins-gitconfig:
+add-jenkins-gitconfig-deploy-user:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/.gitconfig
+        - source: salt://elife/config/home-deploy-user-.gitconfig
+        - mode: 664
+
+add-jenkins-gitconfig-ubuntu-user:
+    file.managed:
+        - name: /home/ubuntu/.gitconfig
         - source: salt://elife/config/home-deploy-user-.gitconfig
         - mode: 664


### PR DESCRIPTION
Since they can commit and push in pipelines, they might as well use a
standard author and email.

This affects `containers` nodes as they are managed by Jenkins and use the `ubuntu` user. `elife-libraries` is already covered by the `elife` user.