### PR TITLE
Make openssl dhparam generation faster

### DIFF
--- a/elife/certificates.sls
+++ b/elife/certificates.sls
@@ -63,7 +63,7 @@ web-complete-cert:
 better-dhe:
     cmd.run:
         - cwd: /etc/ssl/certs
-        - name: openssl dhparam -out dhparam.pem 2048
+        - name: openssl dhparam -dsaparam -out dhparam.pem 2048
         - unless:
             - test -e /etc/ssl/certs/dhparam.pem
 


### PR DESCRIPTION
See advice at https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours

Security implications, if any, to be discussed.