### PR TITLE
Feature: gearman, disables installation of upstart script in non-14.04 instances

### DIFF
--- a/elife/gearman-server.sls
+++ b/elife/gearman-server.sls
@@ -4,6 +4,7 @@ gearman-daemon:
             - gearman-job-server
             - gearman-tools
 
+{% if salt['grains.get']('osrelease') == '14.04' %}
 # the default Upstart script is broken and ignores /etc/default/gearman
 # https://bugs.launchpad.net/ubuntu/+source/gearmand/+bug/1260830/
 # replacing would require an additional restart if we modify the configuration
@@ -15,3 +16,8 @@ gearman-upstart-script:
         - require:
             - gearman-daemon
 
+{% else %}
+
+# 16.04+ come with their own systemd file
+
+{% endif %}


### PR DESCRIPTION
it's not dong any harm right now, I'm just trying to clean up the gearman configuration in `search`