### PR TITLE
multiservice, simplified states after accepting a restart-on-highstate

### DIFF
--- a/elife/multiservice.sls
+++ b/elife/multiservice.sls
@@ -27,6 +27,7 @@
             {% endif %}
             systemctl start {{ process }}-controller.target
         - require:
+            - {{ process }}-controller.target
             - file: {{ opts["service_template"] }} # name of state that manages the systemd service template file
 
 # 3. broken processes fail highstate as they ordinarily would

--- a/elife/multiservice.sls
+++ b/elife/multiservice.sls
@@ -24,8 +24,8 @@
             systemctl disable {{ process }}@ # disable *everything*. implicit reload
             {% if num_processes > 0 %}
             systemctl enable {{ process }}@{0..{{ num_processes - 1}}} # enable just the range we're after. implicit reload
-            {% endif %}
             systemctl start {{ process }}-controller.target
+            {% endif %}
         - require:
             - {{ process }}-controller.target
             - file: {{ opts["service_template"] }} # name of state that manages the systemd service template file

--- a/elife/multiservice.sls
+++ b/elife/multiservice.sls
@@ -8,45 +8,36 @@
 {% for process, opts in pillar.elife.multiservice.services.items() %}
     {% set num_processes = opts["num_processes"] %}
 
-# ensure the target state is available and running
+# ensure the target state controller is available and running
 {{ process }}-controller.target:
     file.managed:
         - name: /lib/systemd/system/{{ process }}-controller.target
         - source: salt://elife/templates/process-controller.target
 
-# ensure precisely N processes are enabled. restart controller if N has changed
-# enabled processes are started when the controller state changes
-{{ process }}-set-disabled:
+# ensure precisely N processes are running
+{{ process }}-set-restart:
     cmd.run:
         - name: |
             set -e
             systemctl stop {{ process }}@{0..99} # stop any running instances of this service.
+            #systemctl stop {{ process }}-controller.target # would also work, but wouldn't catch services outside controller group
             systemctl disable {{ process }}@ # disable *everything*. implicit reload
-        - require:
-            - file: {{ opts["service_template"] }} # name of state that manages the systemd service template file
-        - onlyif:
-            # only run command when the expected number of processes (enabled and running) is not equal to the intended 
-            # number of processes. 
-            # use 'is-enabled' to find enabled units. it conveniently returns 'disabled' if all are disabled, so grep for 'enabled'
-            # use 'show' and grep for the pid for running units. it conveniently returns MainPID=0 for enabled-but-not-running units
-            - test {{ num_processes }} != $(systemctl is-enabled {{ process }}@{0..99} | grep 'enabled' | wc -l) || \
-              test {{ num_processes }} != $(systemctl show {{ process }}@{0..99} | grep '^MainPID=[^0]' | wc -l)
-
-{{ process }}-set-enabled:
-    cmd.run:
-        - name: |
-            set -e
             {% if num_processes > 0 %}
             systemctl enable {{ process }}@{0..{{ num_processes - 1}}} # enable just the range we're after. implicit reload
             {% endif %}
+            systemctl start {{ process }}-controller.target
         - require:
-            - {{ process }}-set-disabled
+            - file: {{ opts["service_template"] }} # name of state that manages the systemd service template file
 
-{{ process }}-controller.target-restart:
-    cmd.run:
-        - name: systemctl restart {{ process }}-controller.target
+# 3. broken processes fail highstate as they ordinarily would
+{% for i in range(0, num_processes) %}
+{{ process }}@{{ i }}:
+    service.running:
+        {% if "init_delay" in opts %}
+        - init_delay: {{ opts["init_delay"] }}
+        {% endif %}
         - require:
-            - {{ process }}-controller.target
-            - {{ process }}-set-enabled
+            - {{ process }}-set-restart
+{% endfor %}
 
 {% endfor %}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -242,6 +242,9 @@ elife:
             ## state that manages the "/lib/systemd/system/myservice@.service" template file
             #   service_template_file:
 
+            ## optional pause after starting service to ensure it didn't die N seconds later
+            #   init_delay:
+
     aws:
         # projects should provide this
         #access_key_id: AKIAFAKE


### PR DESCRIPTION
* it takes about 2 seconds to stop, disable, enable and start 10 of those test services.
* it's a bit shitty, but it will always happen, no conditions and no other states where another bit of the logic resides.
* re-introduces `service.running` state. these were intended to catch process failures that systemd doesn't. systemd just starts the process and if it dies immediately, it still reports it as having successfully started. I've added an optional delay that I think one of the processes in journal-cms would benefit from.

if you're happy with my changes, feel free to merge it into `feat-systemd-targets` and then merge that into `master`