### PR TITLE
Add Helm S3 plugin to publish charts

### DIFF
--- a/elife/helm.sls
+++ b/elife/helm.sls
@@ -14,7 +14,7 @@ helm:
 helm-init:
     cmd.run:
         - name: helm init --client-only
-        - user: {{ pillar.elife.deploy_user.username }}
+        - user: {{ pillar.elife.helm.username }}
         - require:
             - helm
 
@@ -25,7 +25,7 @@ make-dependency:
 helm-s3-plugin:
     cmd.run:
         - name: helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.7.0
-        - user: {{ pillar.elife.deploy_user.username }}
+        - user: {{ pillar.elife.helm.username }}
         - unless:
             -  helm plugin list | grep '^s3 '
         - require:
@@ -36,7 +36,7 @@ helm-s3-plugin:
 helm-s3-charts-repository:
     cmd.run:
         - name: helm repo add alfred s3://prod-elife-alfred/helm-charts
-        - user: {{ pillar.elife.deploy_user.username }}
+        - user: {{ pillar.elife.helm.username }}
         - require:
             - helm-s3-plugin
 {% endif %}

--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -390,3 +390,6 @@ elife:
             observer:
                 host: null
         tmp: /ext/spectrum-tmp
+
+    helm:
+        username: elife


### PR DESCRIPTION
Jenkins needs to initialize it and run it as the `jenkins` user rather than messing with files owned by `jenkins` and commands run as `elife`.