### PR TITLE
Remove support for unsafe TLS 1.0, 1.1

### DIFF
--- a/elife/config/etc-nginx-nginx.conf
+++ b/elife/config/etc-nginx-nginx.conf
@@ -97,7 +97,7 @@ http {
     
     {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
     
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
 
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;


### PR DESCRIPTION
The linked https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html describes 1.2 as the only safe choice.

Impact on browsers is primarily for [IE < 11](https://caniuse.com/#feat=tls1-2) but could be more.