### PR TITLE
Pandoc

### DIFF
--- a/elife/pandoc.sls
+++ b/elife/pandoc.sls
@@ -1,0 +1,8 @@
+pandoc:
+    file.managed:
+        - name: /root/pandoc-2.5-1-amd64.deb
+        - source: https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb
+
+    cmd.run:
+        - name: sudo dpkg -i pandoc-2.5-1-amd64.deb
+        - cwd: /root


### PR DESCRIPTION
I wanted to see if I could find a way to allow `elife-bot-formula` to include `pandoc` on an instance. I need at least version 2.5 so the default Ubuntu release package is not new enough.

Here's my guess at downloading the 64 bit Debian package and installing the executable. I'm not sure how the permissions will get set, or if this will even run. It's a concept to be considered?

Pandoc installation page https://pandoc.org/installing.html#linux

This is using the same version of the package I use for travis-ci tests in the https://github.com/elifesciences/decision-letter-parser library.