### PR TITLE
postgres-container psql9 migration to psql11

### DIFF
--- a/elife/postgresql-11.sls
+++ b/elife/postgresql-11.sls
@@ -13,7 +13,7 @@ postgresql-deb:
         - name: deb http://apt.postgresql.org/pub/repos/apt/ {{ oscodename }}-pgdg main
         - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 
-# copied from 
+# /copied from
 
 pgpass-file:
     file.managed:

--- a/elife/postgresql-container.sls
+++ b/elife/postgresql-container.sls
@@ -1,3 +1,32 @@
+# temporary, remove once all postgresql-container projects are upgraded to 11+
+{% set psql9 = pillar.elife.docker_postgresql.image_tag.startswith("9.") %}
+
+# copied from postgresql-client.sls
+
+{% set oscodename = salt['grains.get']('oscodename') %}
+
+# http://www.postgresql.org/download/linux/ubuntu/
+postgresql-deb:
+    pkgrepo.managed:
+        # http://www.postgresql.org/download/linux/ubuntu/
+        - humanname: Official Postgresql Ubuntu LTS
+        - name: deb http://apt.postgresql.org/pub/repos/apt/ {{ oscodename }}-pgdg main
+        - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+
+postgresql-client:
+    pkg.installed:
+        - pkgs:
+            {% if psql9 %}
+            - postgresql-client-9.4
+            {% else %}
+            - postgresql-client-11
+            {% endif %}
+        - refresh: True
+        - require:
+            - pkgrepo: postgresql-deb
+
+# /copied from
+
 docker-compose-postgres:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/postgres/docker-compose.yml
@@ -38,6 +67,25 @@ stop-disable-host-postgresql:
             systemctl disable postgresql || true # service units already deleted or postgresql never installed
             # don't do this, messes with systemctl, can mess with apt, doesn't stop postgresql from running
             #rm -f /lib/systemd/system/postgresql*
+
+{% if not psql9 %}
+
+# stops any postgres:9 docker processes and removes them
+# image is then rebuilt using postgres-11 and started in docker-compose-postgres-up
+stop-remove-postgresql9-process:
+    cmd.run:
+        - name: |
+            set -e
+            psid=$(docker ps -a | grep "postgres:9" | awk '{ print $1 }')
+            test ! -z "$psid" && {
+                docker stop "$psid"
+                docker rm "$psid"
+            } || {
+                echo "docker postgres 9.x process not found"
+            }
+        - require_in:
+            - cmd: stop-remove-postgresql9-process
+{% endif %}
 
 docker-compose-postgres-up:
     cmd.run:


### PR DESCRIPTION
* adds migration (destroy/recreate) for psql 9 processes
* incorporates postgresql-client into postgres-container