### PR TITLE
Reintroduce timeout with --foreground

### DIFF
--- a/elife/config/usr-local-bin-daily-system-update
+++ b/elife/config/usr-local-bin-daily-system-update
@@ -12,7 +12,10 @@ fi
 
 log_file=/var/log/daily-system-update.log
 set -o pipefail
-sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee $log_file || {
+# timeout requires --foreground to safely run outside of a shell
+# to avoid putting the wrapped process in the background
+# https://github.com/elifesciences/issues/issues/5163
+sudo timeout --foreground salt-call --force-color state.highstate -l info --retcode-passthrough | tee $log_file || {
     status=$?
     echo "Error in daily-system-update, state.highstate returned: ${status}"
     logger "Salt highstate failure: $log_file on $(hostname)"


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/5163

According to https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html this seems to imply that the combination of `docker-compose exec` and `sudo` is "interactive" e.g. reads from the terminal.