### PR TITLE
Limit systemd disk space

### DIFF
--- a/elife/init.sls
+++ b/elife/init.sls
@@ -4,6 +4,7 @@
 include:
     - .base
     - .python
+    - .systemd
     - .hostname
     - .dhcp
     - .known-hosts

--- a/elife/systemd.sls
+++ b/elife/systemd.sls
@@ -1,0 +1,10 @@
+/etc/systemd/journald.conf:
+    file.replace:
+        - pattern: "^#?SystemMaxUse=.*"
+        - repl: "SystemMaxUse=100M"
+
+systemd-journald:
+    service.running:
+        - enable: True
+        - watch:
+            - file: /etc/systemd/journald.conf


### PR DESCRIPTION
Otherwise /var/log/journal can grow to 800MB over months