### PR TITLE
Switch proofreader Vagrant default to 0.2

### DIFF
--- a/pillar/elife.sls
+++ b/pillar/elife.sls
@@ -223,7 +223,7 @@ elife:
                 #    number: 1
                 #    [require: some-state]
     proofreader_php:
-        version: 0.1
+        version: 0.2
 
     php_dummies: {}
         #orcid_dummy:


### PR DESCRIPTION
Matches
https://github.com/elifesciences/builder-private/blob/3b6cb4539d13a2b42165cff93f04345c00389c3f/pillar/elife.sls#L300