### PR TITLE
/usr/local/utils

### DIFF
--- a/elife/base.sls
+++ b/elife/base.sls
@@ -37,6 +37,9 @@ base:
             - sysstat # provides iostat
             - iotop
 
+            # useful for smoke testing the JSON output
+            - jq
+
 base-purging:
     pkg.purged:
         - pkgs:

--- a/elife/config/etc-profile.d-utils-path.sh
+++ b/elife/config/etc-profile.d-utils-path.sh
@@ -1,1 +1,0 @@
-export PATH=/usr/local/utils:$PATH

--- a/elife/utils.sls
+++ b/elife/utils.sls
@@ -15,4 +15,3 @@ utils-scripts:
 utils-scripts-path:
     file.absent:
         - name: /etc/profile.d/utils-path.sh
-        - source: salt://elife/config/etc-profile.d-utils-path.sh

--- a/elife/utils.sls
+++ b/elife/utils.sls
@@ -1,25 +1,18 @@
 utils-scripts:
     file.recurse:
-        - name: /usr/local/utils/
+        # this state copies the scripts:
+        # build_vars, retry, set_local_revision, update_python_dependency, wait_for_port
+        # this directory was only available in interactive login shells
+        # it was not available to commands executed using su or sudo
+        # for example, running a cmd.run state with a user other than root
+        # or sudo'ing to root to run a command
+        #- name: /usr/local/utils/
+        # this directory is always on the PATH
+        - name: /usr/local/bin
         - source: salt://elife/utils
         - file_mode: 555
 
 utils-scripts-path:
-    file.managed:
+    file.absent:
         - name: /etc/profile.d/utils-path.sh
         - source: salt://elife/config/etc-profile.d-utils-path.sh
-        - mode: 644
-
-utils-packages:
-    pkg.installed:
-        - pkgs:
-            # useful for smoke testing the JSON output
-            - jq
-
-elife-utils-ready:
-    cmd.run:
-        - name: echo "utils can now be used"
-        - require:
-            - utils-scripts
-            - utils-scripts-path
-            - utils-packages


### PR DESCRIPTION
* moves contents of /usr/local/utils to /usr/local/bin
* adds a comment to improve grep'ability of the scripts being copied.