### PR TITLE
removes mentions of py2 'has_key'

### DIFF
--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -13,7 +13,7 @@ def first(x):
 
 def firstnn(lst):
     "returns first non-nil value in lst or None"
-    return first(filter(None, lst))
+    return first([_f for _f in lst if _f])
     
 def lookup(data, path, default=0xDEADBEEF):
     try:

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -88,7 +88,7 @@ def read_json(path):
         contents = open(path, 'r').read()
         if path.endswith('.b64'):
             # file is base64 encoded
-            contents = base64.b64decode(contents)
+            contents = base64.b64decode(contents).decode('utf-8')
         try:
             return json.loads(contents)
         except ValueError:

--- a/_modules/elife.py
+++ b/_modules/elife.py
@@ -115,7 +115,7 @@ def cfg(*paths):
         'cfn': cfn() # stack 'creation' time data
     }
     # don't raise exceptions if path value not found. very django-like
-    return firstnn(map(lambda path: lookup(data, path, default=None), paths)) or default 
+    return firstnn([lookup(data, path, default=None) for path in paths]) or default 
 
 def b64encode(string):
     # used by the salt/elife-website/load-tester.sh:21

--- a/elife/deploy-user.sls
+++ b/elife/deploy-user.sls
@@ -63,7 +63,7 @@ vagrant-user:
 {% set allowed = ssh.allowed.get(pname, []) + ssh.allowed.get("all", []) %}
 
 {% for username in allowed %}
-    {% if pillar.elife.ssh_users.has_key(username) %}
+    {% if username in pillar.elife.ssh_users %}
 
 {{ pname }}-ssh-access-for-{{ username }}:
     ssh_auth.present:
@@ -97,7 +97,7 @@ vagrant-user:
 {% set denied = ssh.denied.get(pname, []) + ssh.denied.get("all", []) %}
 
 {% for username in denied %}
-    {% if pillar.elife.ssh_users.has_key(username) %}
+    {% if username in pillar.elife.ssh_users %}
 
 {{ pname }}-ssh-denial-for-{{ username }}:
     ssh_auth.absent:

--- a/elife/masterless.sls
+++ b/elife/masterless.sls
@@ -28,7 +28,7 @@ deny_all_access:
 
 {% set allowed = ssh.allowed.get('master-server', []) + ssh.allowed.get("all", []) %}
 {% for username in allowed %}
-    {% if pillar.elife.ssh_users.has_key(username) %}
+    {% if username in pillar.elife.ssh_users %}
 
 masterless-ssh-access-for-{{ username }}:
     ssh_auth.present:
@@ -51,7 +51,7 @@ masterless-ssh-access:
 {% set denied = ssh.denied.get("master-server", []) + ssh.denied.get("all", []) %}
 
 {% for username in denied %}
-    {% if pillar.elife.ssh_users.has_key(username) %}
+    {% if username in pillar.elife.ssh_users %}
 
 masterless-ssh-denial-for-{{ username }}:
     ssh_auth.absent:


### PR DESCRIPTION
Don't know how these lot slipped by. Salt upgrade on a master-server and heavybox worked fine on vagrant. `has_key` should have failed in those cases. 

The second problem with the generator vs list might have slipped through because vagrant boxes don't have /etc/cfn_info json