### PR TITLE
adds 'clean' and 'autoclean' to base.sls

### DIFF
--- a/elife/base.sls
+++ b/elife/base.sls
@@ -63,7 +63,6 @@ autoremove-orphans:
         - name: |
             set -e 
             apt-get autoremove -y
-            apt-get clean -y
             apt-get autoclean -y
         - env:
             - DEBIAN_FRONTEND: noninteractive

--- a/elife/base.sls
+++ b/elife/base.sls
@@ -60,7 +60,11 @@ base-updatedb-config:
 
 autoremove-orphans:
     cmd.run:
-        - name: apt-get autoremove -y
+        - name: |
+            set -e 
+            apt-get autoremove -y
+            apt-get clean -y
+            apt-get autoclean -y
         - env:
             - DEBIAN_FRONTEND: noninteractive
         - require:


### PR DESCRIPTION
from a fresh elife-bot masterless instance:

```bash
elife@sizeinspection--bot:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           396M  5.8M  390M   2% /run
/dev/xvda1      7.7G  3.6G  4.2G  47% /
tmpfs           2.0G   16K  2.0G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/xvdh        30G   44M   28G   1% /bot-tmp
tmpfs           396M     0  396M   0% /run/user/1001
```
```bash
elife@sizeinspection--bot:~$ sudo apt-get clean
elife@sizeinspection--bot:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           396M  5.8M  390M   2% /run
/dev/xvda1      7.7G  3.2G  4.6G  42% /
tmpfs           2.0G   16K  2.0G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/xvdh        30G   44M   28G   1% /bot-tmp
tmpfs           396M     0  396M   0% /run/user/1001
```

```bash
elife@sizeinspection--bot:~$ sudo apt-get autoclean
Reading package lists... Done
Building dependency tree       
Reading state information... Done
elife@sizeinspection--bot:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           396M  5.8M  390M   2% /run
/dev/xvda1      7.7G  3.3G  4.5G  43% /
tmpfs           2.0G   16K  2.0G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/xvdh        30G   44M   28G   1% /bot-tmp
tmpfs           396M     0  396M   0% /run/user/1001
```

```bash
elife@sizeinspection--bot:~$ sudo apt-get autoremove
Reading package lists... Done
Building dependency tree       
Reading state information... Done
0 upgraded, 0 newly installed, 0 to remove and 272 not upgraded.
elife@sizeinspection--bot:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           396M  5.8M  390M   2% /run
/dev/xvda1      7.7G  3.3G  4.5G  43% /
tmpfs           2.0G   16K  2.0G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/xvdh        30G   44M   28G   1% /bot-tmp
tmpfs           396M     0  396M   0% /run/user/1001
```

```bash
elife@sizeinspection--bot:~$ sudo salt-call state.highstate
[INFO    ] Failed to get mtime on /srv/salt/pillar/top.sls, dangling symlink?

[...]

elife@sizeinspection--bot:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           396M  5.8M  390M   2% /run
/dev/xvda1      7.7G  3.3G  4.5G  43% /
tmpfs           2.0G   16K  2.0G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/xvdh        30G   44M   28G   1% /bot-tmp
tmpfs           396M     0  396M   0% /run/user/1001
```