### PR TITLE
sidecars, healthcheck fix

### DIFF
--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -23,7 +23,7 @@ docker-compose-{{ configuration['name'] }}:
             ports: {{ configuration.get('ports', {})|yaml }}
             environment: {{ configuration.get('environment', {})|yaml }}
             volumes: {{ configuration.get('volumes', [])|yaml }}
-            healthcheck: {{ configuration.get('healthcheck') }}
+            healthcheck: {{ configuration.get('healthcheck')|yaml }}
         - makedirs: True
         - require: 
             - deploy-user

--- a/elife/sidecars.sls
+++ b/elife/sidecars.sls
@@ -23,7 +23,7 @@ docker-compose-{{ configuration['name'] }}:
             ports: {{ configuration.get('ports', {})|yaml }}
             environment: {{ configuration.get('environment', {})|yaml }}
             volumes: {{ configuration.get('volumes', [])|yaml }}
-            healthcheck: {{ configuration.get('healthcheck')|yaml }}
+            healthcheck: {{ configuration.get('healthcheck', '') }}
         - makedirs: True
         - require: 
             - deploy-user


### PR DESCRIPTION
this removes the `healthcheck: None` we're seeing in `profiles`.

only personalised covers is using the health check:

* https://github.com/elifesciences/builder-configuration/blob/4b085410a4c9923613f97c273e1a75b975a812b9/pillar/personalised-covers-ci-public.sls#L16
* https://github.com/elifesciences/personalised-covers-formula/blob/6c12a674b8e5f50e2f014340088d42d8007a3ef9/salt/pillar/personalised-covers.sls#L34
