### PR TITLE
mysql-client, removes 'hash' elements in file.patch

### DIFF
--- a/elife/mysql-client.sls
+++ b/elife/mysql-client.sls
@@ -17,9 +17,6 @@ mysql-package-list:
     file.patch:
         - name: /usr/lib/python3/dist-packages/MySQLdb/cursors.py
         - source: salt://elife/config/usr-lib-python3-dist-packages-MySQLdb-cursors.py.patch
-        # md5 of original file: aca2fb480a76e30f65601018916e86bd
-        # md5 of patched file:
-        - hash: 15d883d28d4548374522fad16eed560e
         - require:
             # this file is placed here by the above state
             - pkg: mysql-package-list


### PR DESCRIPTION
* element is now ignored
* this will fix a warning in `journal-cms`