### PR TITLE
composer, fixes major version to the 1.x.x line.

### DIFF
--- a/elife/composer.sls
+++ b/elife/composer.sls
@@ -62,7 +62,7 @@ install-composer:
             - which composer
     cmd.run:
         - cwd: {{ composer_home }}
-        - name: php setup.php --install-dir=/usr/local/bin --filename=composer
+        - name: php setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.16
         - require:
             - php
             - file: install-composer

--- a/elife/scripts/update-composer.sh
+++ b/elife/scripts/update-composer.sh
@@ -4,7 +4,7 @@ set -e
 log_file="/tmp/update-composer-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
 
 set -o pipefail
-if ! composer self-update 2>&1 | tee "$log_file"; then
+if ! composer self-update --1 2>&1 | tee "$log_file"; then
     echo "Composer update failure detected."
     if grep "Connection timed out" "$log_file"; then
         echo "Retrying update..."


### PR DESCRIPTION
at time of writing api-dummy (and who knows what else) is failing to build on composer 2.x.x

see https://github.com/elifesciences/personalised-covers-formula/pull/34