### PR TITLE
postgresql 11, appdb, upgrades password encryption to scram-sha-256.

### DIFF
--- a/elife/postgresql-11.sls
+++ b/elife/postgresql-11.sls
@@ -1,5 +1,6 @@
+# postgresql 11
 # postgresql-11.sls is intended to be a drop-in replacement for postgresql.sls (psql 9.4)
-# the two are mutually exclusive and share many of the same state names
+# the two are mutually exclusive and share many of the same state names.
 
 # copied from postgresql-client.sls
 
@@ -126,6 +127,7 @@ rds-postgresql-user:
     postgres_user.present:
         - name: {{ pillar.elife.db_root.username }}
         - password: {{ salt['elife.cfg']('project.rds_password') }}
+        - encrypted: scram-sha-256
         - refresh_password: True
         - db_password: {{ salt['elife.cfg']('project.rds_password') }}
         - db_host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') }}
@@ -143,6 +145,7 @@ postgresql-user:
     postgres_user.present:
         - name: {{ pillar.elife.db_root.username }}
         - password: {{ pillar.elife.db_root.password }}
+        - encrypted: scram-sha-256
         - refresh_password: True
         - db_password: {{ pillar.elife.db_root.password }}
         

--- a/elife/postgresql-appdb.sls
+++ b/elife/postgresql-appdb.sls
@@ -53,7 +53,7 @@ psql-app-db:
     postgres_user.present:
         - name: {{ app_user_name }}
         - password: {{ app_user_pass }}
-        - encrypted: True
+        - encrypted: scram-sha-256
         - refresh_password: True
         - createdb: {% if pillar.elife.env in ['prod', 'end2end'] %}False{% else %}True{% endif %}
 


### PR DESCRIPTION
this fixes a deprecation warning in salt and postgresql.