### PR TITLE
aws-cli, replaces system-wide pip install of aws-cli with a wrapper.

### DIFF
--- a/elife/aws-cli.sls
+++ b/elife/aws-cli.sls
@@ -1,5 +1,20 @@
-aws-cli:
+
+# lsh@2022-10-12: `awscli` was originally installed with pip because the system package got old quickly.
+# This was in 12.04 or 14.04. In 20.04 it may be more stable however I've opted to continue using the latest 
+# but wrapping it in a script with it's own virtualenv because of library mismatches with openssl:
+# - https://github.com/elifesciences/issues/issues/7782
+
+remove-aws-cli:
     cmd.run:
-        - name: |
-            python3 -m pip install 'awscli~=1.16' --upgrade --quiet
-            aws --version
+        - name: python3 -m pip uninstall awscli --quiet -y
+
+    pkg.purged:
+        - name: awscli
+
+aws-cli:
+    file.managed:
+        - name: /usr/local/bin/aws
+        - source: salt://elife/scripts/aws
+        - mode: 775
+        - require:
+            - remove-aws-cli

--- a/elife/scripts/aws
+++ b/elife/scripts/aws
@@ -1,0 +1,50 @@
+#!/bin/bash
+# self-contained awscli wrapper.
+# creates a virtualenv at "~/.aws-cli-venv".
+# run as any user.
+
+set -e
+
+venv_path="$(realpath ~/.aws-cli-venv)"
+
+# echo to stderr.
+# output of this script shouldn't interfere with output of awscli.
+function errcho { echo "$@" >&2; }
+
+# mkvenv.sh boilerplate
+
+python=''
+pybinlist=("python3.8" "python3")
+
+for pybin in "${pybinlist[@]}"; do
+    which "$pybin" &> /dev/null || continue
+    python=$pybin
+    break
+done
+
+if [ -z "$python" ]; then
+    errcho "no usable python found, exiting"
+    exit 1
+fi
+
+if [ ! -e "$venv_path/bin/$python" ]; then
+    errcho "could not find $venv_path/bin/$python, recreating venv"
+    rm -rf "$venv_path"
+    $python -m venv "$venv_path"
+fi
+
+# activate
+
+source "$venv_path"/bin/activate
+
+# install, but only if aws-cli not detected
+
+if [ ! -e "$venv_path/bin/aws" ]; then
+    errcho "could not find $venv_path/bin/awscli, installing"
+    pip install pip wheel --upgrade >&2
+    pip install awscli >&2
+fi
+
+# wrap
+
+"$venv_path"/bin/aws "$@"


### PR DESCRIPTION
wrapper will create a local venv if necessary and install awscli that way.