### PR TITLE
daily-system-updates, 'daily-security-update' script now actually downloads and installs security updates.

### DIFF
--- a/elife/config/usr-local-bin-daily-security-update
+++ b/elife/config/usr-local-bin-daily-security-update
@@ -10,14 +10,10 @@ if [ -e "${created_file}" ]; then
     exit 0
 fi
 
-# there is no guarantee that `apt-daily` covers the programs in 
-# `/etc/cron.daily`, so continue to call run-parts on them.
+# for machines that are turned off most of the time.
 run-parts /etc/cron.daily
 
-# lsh@2022-10-25, more context here:
-# - https://github.com/elifesciences/issues/issues/7823
-
-# downloads updates (among other things). 
+# downloads updates (among other things).
 # this is a 'one-shot' script and not a daemon that stays running.
 # see: /usr/lib/apt/apt.systemd.daily
 systemctl start apt-daily


### PR DESCRIPTION
this script is *still* not run as the daily and daily-upgrade timers have been disabled, which is intentional. Instead, Jenkins is used to automate calling this script then reboots instance.