### PR TITLE
base.sls, removes /tmp/snap-private-tmp as part of snap purge.

### DIFF
--- a/elife/base.sls
+++ b/elife/base.sls
@@ -152,7 +152,8 @@ snapd:
             - amazon-ssm-agent-snap-removal
 
     cmd.run:
-        - name: rm -rf /var/cache/snapd
+        - name: |
+            rm -rf /var/cache/snapd /tmp/snap-private-tmp
         - require:
             - service: snapd
         - require_in:


### PR DESCRIPTION
elife-dashboard is using the 'chromium-browser' package on non-prod to run it's tests, which installs snap. so on each highstate, snap is purged, chromium+snap is installed, tests are run. however the installation of either snap or chromium will fail if that private snap tmp is present. Unsure if this is new behaviour or if it's just the first time I've noticed it.