### PR TITLE
postgresql 11, allow docker containers to access host psql

### DIFF
--- a/elife/config/etc-postgresql-11-conf.d-docker.conf
+++ b/elife/config/etc-postgresql-11-conf.d-docker.conf
@@ -1,0 +1,1 @@
+listen_addresses = 'localhost,172.17.0.1'

--- a/elife/config/etc-postgresql-11-main-pg_hba.conf
+++ b/elife/config/etc-postgresql-11-main-pg_hba.conf
@@ -97,3 +97,6 @@ host    all             all             ::1/128                 md5
 #local   replication     all                                     peer
 #host    replication     all             127.0.0.1/32            md5
 #host    replication     all             ::1/128                 md5
+
+# lsh@2022-12-20: allow docker containers to access host psql
+host    all             all             172.0.0.0/8             md5

--- a/elife/postgresql-11.sls
+++ b/elife/postgresql-11.sls
@@ -85,6 +85,18 @@ postgresql-config:
         - require_in:
             - cmd: postgresql-ready
 
+# lsh@2022-12-20: allow docker containers to access host psql
+postgresql-docker-config:
+    file.managed:
+        - name: /etc/postgresql/11/main/conf.d/docker.conf
+        - source: salt://elife/config/etc-postgresql-11-conf.d-docker.conf
+        - require:
+            - pkg: postgresql
+        - watch_in:
+            - service: postgresql
+        - require_in:
+            - cmd: postgresql-ready
+
 # runs pg_upgrade on 9.4 data and then purge postgresql-9.4 
 psql-9.4 to psql-11 migration:
     file.managed:


### PR DESCRIPTION
just psql 11 for now as it affects `profiles` only. 