### PR TITLE
multiservice, switches from enabling processes using bash-brace syntax.

### DIFF
--- a/elife/multiservice.sls
+++ b/elife/multiservice.sls
@@ -60,7 +60,7 @@
 # - https://github.com/elifesciences/issues/issues/7980
 stop-disable-bogus-process--{{ process }}:
     service.dead:
-        - name: "{{ process }}@\x7b0..{{ num_processes - 1 }}\x7d"
+        - name: '{{ process }}@\x7b0..{{ num_processes - 1 }}\x7d'
         - enable: false
 
 {% endfor %}


### PR DESCRIPTION
stops and disables bogus processes.