### PR TITLE
external-volume-srv.sls, fix for salt 3006 file.symlink changed behaviour

### DIFF
--- a/elife/external-volume-srv.sls
+++ b/elife/external-volume-srv.sls
@@ -8,15 +8,17 @@ srv-directory:
         - require:
             - mount-external-volume
             - resize-external-volume-if-needed
-        #- require_in:
-        #    - file: new-ubr-config
 
 srv-directory-linked:
     cmd.run:
-        - name: mv /srv/* /ext/srv
+        - name: (mv /srv/* /ext/srv || true) && rmdir /srv
         - onlyif:
+            # lsh@2023-05-17: in salt 3006 file.symlink behaviour has changed and an empty /srv directory now breaks the state.
+            # the disabled requisite works well but would prevent the new 'rmdir /srv' from being run.
+            # problems moving files from /srv that would have failed the state now fail when rmdir tries to delete a non-empty dir.
             # /srv/ has something in it to move
-            - ls -l /srv/ | grep -v 'total 0'
+            #- ls -l /srv/ | grep -v 'total 0'
+            # /srv is not already a symlink
             - test ! -L /srv
         - require:
             - srv-directory


### PR DESCRIPTION

the empty /srv directory is now deleted after being emptied.