### PR TITLE
pypi, replaces pip installed twine with package twine.

### DIFF
--- a/elife/pypi.sls
+++ b/elife/pypi.sls
@@ -14,10 +14,18 @@ pypi-credentials-ubuntu-user:
         - require:
             - deploy-user
 
+# lsh@2023-06-12: installing pip this way is installing an incompatible set of requests and urllib3.
+# it's also general bad practice, messing with system packages
+# see: https://github.com/docker/docker-py/issues/3113
+#twine:
+#    cmd.run:
+#        # TODO: try to remove this workaround on 16.04
+#        # ignore-installed because of a conflict with the chardet Python package
+#        # https://stackoverflow.com/questions/50130004/installing-twine-fails-because-cannot-uninstall-pkginfo#comment96655925_50132754
+#        # lsh@2020-01-13: changed from 'pip' to 'python3 -m pip'
+#        #- name: python3 -m pip install twine --ignore-installed --quiet
+
 twine:
-    cmd.run:
-        # TODO: try to remove this workaround on 16.04
-        # ignore-installed because of a conflict with the chardet Python package
-        # https://stackoverflow.com/questions/50130004/installing-twine-fails-because-cannot-uninstall-pkginfo#comment96655925_50132754
-        # lsh@2020-01-13: changed from 'pip' to 'python3 -m pip'
-        - name: python3 -m pip install twine --ignore-installed --quiet
+    pkg.installed:
+        - pkgs:
+            - twine


### PR DESCRIPTION
this is because 'twine' is using unbounded versions of requests and urllib3 and requests<2.28.2 and urllib3>=2 are incompible. this in turn breaks docker-compose, which is actually a python wrapper around ... urgh.