### PR TITLE
newrelic, adds elife/newrelic-python-removal.sls

### DIFF
--- a/elife/newrelic-python-removal.sls
+++ b/elife/newrelic-python-removal.sls
@@ -1,0 +1,5 @@
+newrelic-python-license-configuration:
+    file.absent:
+        - name: {{ pillar.elife.newrelic_python.application_folder }}/newrelic.ini
+        - listen_in:
+            - service: {{ pillar.elife.newrelic_python.service }}


### PR DESCRIPTION
it removes the licence file in the application's folder and restarts the app.