### PR TITLE
cloud-init, explicitly enables dhcpv4 as well as dhcpv6.

### DIFF
--- a/elife/config/etc-cloud-cloud.cfg.d-10_enable-dhcp-ipv6.cfg
+++ b/elife/config/etc-cloud-cloud.cfg.d-10_enable-dhcp-ipv6.cfg
@@ -3,4 +3,5 @@ network:
   version: 2
   ethernets:
      ens5:
+        dhcp4: true
         dhcp6: true


### PR DESCRIPTION
I just had a problem with the jenkins ec2 container instances where they weren't receiving an ipv4 address but did have ipv6 address. The subnet they were launched into didn't have ipv6 routing configuring at all and were unreachable. Did they not receive an ipv4 address because they already had an ipv6? I don't know.