### PR TITLE
base.sls, re-enables cloud-init validation,

### DIFF
--- a/elife/base.sls
+++ b/elife/base.sls
@@ -178,12 +178,13 @@ cloud-init-dhcp-ipv6:
         - name: /etc/cloud/cloud.cfg.d/10_enable-dhcp-ipv6.cfg
         - source: salt://elife/config/etc-cloud-cloud.cfg.d-10_enable-dhcp-ipv6.cfg
     
-    # lsh@2024-02-23: working in cloud-init 23.3, broken in cloud-init 23.4.3
-    # possibly a bug, doesn't appear to affect assignment of ipv6 addresses.
-    #cmd.run:
-    #    - name: cloud-init schema -c /etc/cloud/cloud.cfg.d/10_enable-dhcp-ipv6.cfg
-    #    - creates: /etc/cloud/cloud.cfg.d/10_enable-dhcp-ipv6.valid
-    #    - require:
-    #        - base-latest-pkgs
-    #        - file: cloud-init-dhcp-ipv6
+    cmd.run:
+        # lsh@2024-02-23: was working in cloud-init 23.3 but is broken in cloud-init 23.4.3
+        # see: https://github.com/canonical/cloud-init/issues/4944
+        #- name: cloud-init schema -c /etc/cloud/cloud.cfg.d/10_enable-dhcp-ipv6.cfg
+        - name: cloud-init schema --system
+        - creates: /etc/cloud/cloud.cfg.d/10_enable-dhcp-ipv6.valid
+        - require:
+            - base-latest-pkgs
+            - file: cloud-init-dhcp-ipv6
 

--- a/elife/config/etc-cloud-cloud.cfg.d-10_enable-dhcp-ipv6.cfg
+++ b/elife/config/etc-cloud-cloud.cfg.d-10_enable-dhcp-ipv6.cfg
@@ -1,4 +1,3 @@
-#cloud-config
 network:
   version: 2
   ethernets:


### PR DESCRIPTION
the invocation I was using didn't specify the type of config it was looking at and defaulting to the wrong thing. it was being lenient and giving it the thumbs up but an update makes it more strict. turns out individual validation for 'network: version: 2' snippets won't be present until v24.1. until then global validation is possible and recommended.